### PR TITLE
chore(ci): bump actions to Node24-compatible versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,18 +28,18 @@ jobs:
 
     steps:
       - name: Checkout packages repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: packages
 
       - name: Set up Go (GOTOOLCHAIN=auto upgrades as needed per service)
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "stable"
           check-latest: true
 
       - name: Set up Node (for frontend)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
 
@@ -97,7 +97,7 @@ jobs:
 
       - name: Upload RPM artefacts
         if: success() || failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: duynhlab-rpms
           path: packages/dist/*.rpm

--- a/.github/workflows/publish-yum-repo.yml
+++ b/.github/workflows/publish-yum-repo.yml
@@ -37,12 +37,12 @@ jobs:
 
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: packages
 
       - name: Checkout gh-pages (will be created if missing)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: gh-pages
           path: gh-pages
@@ -63,13 +63,13 @@ jobs:
           fi
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "stable"
           check-latest: true
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
 

--- a/.github/workflows/smoke-test-rpm.yml
+++ b/.github/workflows/smoke-test-rpm.yml
@@ -30,16 +30,16 @@ jobs:
 
     steps:
       - name: Checkout packages
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: packages
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with: { go-version: "stable", check-latest: true }
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with: { node-version: "20" }
 
       - name: Install host tools (yq, podman)
@@ -93,7 +93,7 @@ jobs:
 
       - name: Upload RPMs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: duynhlab-rpms-smoke
           path: packages/dist/*.rpm


### PR DESCRIPTION
Resolves Node.js 20 deprecation warning.

- `actions/checkout` v4 -> v6
- `actions/setup-go` v5 -> v6
- `actions/setup-node` v4 -> v6
- `actions/upload-artifact` v4 -> v7