### PR TITLE
fix(ci): stage Source0 before build-rpm in publish + smoke workflows

### DIFF
--- a/.github/workflows/publish-yum-repo.yml
+++ b/.github/workflows/publish-yum-repo.yml
@@ -99,8 +99,14 @@ jobs:
         working-directory: packages
         run: ./scripts/render-systemd.sh
 
+      - name: Stage Source0 tarball
+        working-directory: packages
+        run: ./scripts/stage-all.sh
+
       - name: Build mega-RPM
         working-directory: packages
+        env:
+          BUILD_RUNNER: docker
         run: ./scripts/build-rpm.sh
 
       - name: Stage YUM repo into gh-pages tree

--- a/.github/workflows/smoke-test-rpm.yml
+++ b/.github/workflows/smoke-test-rpm.yml
@@ -70,8 +70,14 @@ jobs:
         working-directory: packages
         run: ./scripts/render-systemd.sh
 
+      - name: Stage Source0 tarball
+        working-directory: packages
+        run: ./scripts/stage-all.sh
+
       - name: Build mega-RPM
         working-directory: packages
+        env:
+          BUILD_RUNNER: docker
         run: ./scripts/build-rpm.sh
 
       - name: Quick smoke (file-level)


### PR DESCRIPTION
publish-yum-repo and smoke-test-rpm failed at 'Build mega-RPM' because the Source0 staging tarball was never produced (same root cause already fixed in build.yml).

- Add `scripts/stage-all.sh` step before `build-rpm.sh`
- Set `BUILD_RUNNER: docker` explicitly

Fixes publish-yum-repo run failures.