### PR TITLE
docs: standardize documentation with diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,119 @@
 # duynhlab/packages
 
-> **Status**: Refactor in progress (Phase 0 complete, Phase 1 in progress).
-> See [`plan.md`](./plan.md) for the full roadmap and [`AGENTS.md`](./AGENTS.md) for repo conventions.
+Distribution layer for the **duynhlab** e-commerce platform. It repacks the
+Go binaries and frontend build from the upstream `duynhlab/*-service` repos
+into a single **mega-RPM** and publishes it through a YUM repository hosted on
+GitHub Pages.
 
-Distribution layer for the duynhlab platform: repacks per-service Go binaries from upstream service repos into RPMs (and later DEBs), serves them via a YUM repository on GitHub Pages.
+- **Format**: RPM (EL9 / Rocky · AlmaLinux · RHEL 9, `x86_64`)
+- **Build tool**: `rpmbuild` against [`specs/duynhlab.spec`](specs/duynhlab.spec) — no nFPM, no Docker build image
+- **Output**: `duynhlab-<VERSION>-1.el9.x86_64.rpm` (8 backends + frontend + CLI + config templates)
+- **Source of truth**: [`services.yaml`](services.yaml) — every script and workflow renders from it
 
-## Scope (v1)
+## What ships in the package
 
-- **Format**: RPM only (DEB → Phase 4)
-- **Target**: EL9 (Rocky/AlmaLinux 9), amd64
-- **Services**: 8 backend (`auth`, `user`, `product`, `cart`, `order`, `review`, `notification`, `shipping`) + 1 frontend
-- **Source of binaries**: GitHub Release tarballs of each `duynhlab/<svc>-service` repo
+| Component | Path (installed) |
+|---|---|
+| 8 Go backends (`auth` … `shipping`) | `/opt/duynhlab/<svc>/bin/<svc>-service` |
+| Frontend SPA (static) | `/opt/duynhlab/frontend/dist/` |
+| CLI tools | `/usr/bin/duynhlab-{ctl,db-setup,db-migrate,gen-env,gen-password}` |
+| systemd units + targets | `/usr/lib/systemd/system/duynhlab-*.{service,target}` |
+| Config templates (nginx/valkey/postgresql/logrotate) | `/opt/duynhlab/<tool>/` → dropped into `/etc/*` on install |
+| Mutable env + secrets | `/etc/duynhlab/<svc>.env` (random password, 0640) |
 
-## Layout
+## Quick start
+
+### Install (end user)
+
+```bash
+sudo curl -fsSL -o /etc/yum.repos.d/duynhlab.repo \
+  https://duynhlab.github.io/packages/duynhlab.repo
+sudo dnf install -y duynhlab
+
+SUPERUSER_DSN="postgresql://postgres:secret@localhost:5432/postgres" \
+  sudo -E duynhlab-db-setup bootstrap
+sudo duynhlab-db-setup migrate
+sudo systemctl enable --now duynhlab-platform.target
+```
+
+Full guide: [`docs/install.md`](docs/install.md).
+
+### Build locally (maintainer)
+
+```bash
+make fetch-sources          # clone every service repo into ../
+make build-local-all        # compile binaries + frontend dist
+make build                  # stage Source0 tarball + rpmbuild -> dist/*.rpm
+make smoke                  # file-level install check in Rocky 9
+make publish-repo           # stage gh-pages YUM tree under build/gh-pages/
+```
+
+`BUILD_RUNNER=host|podman|docker` is auto-detected. See
+[`docs/build.md`](docs/build.md).
+
+## Pipeline at a glance
+
+```mermaid
+flowchart LR
+  subgraph upstream["duynhlab/*-service repos"]
+    A1[auth-service]
+    A2[user-service]
+    A3[… 6 more]
+    F[frontend]
+  end
+
+  upstream -->|fetch-sources.sh<br/>git clone| SRC[(../&lt;svc&gt;)]
+  SRC -->|build-local.sh<br/>go build / npm build| RAW[build/&lt;svc&gt;/raw/*.tar.gz]
+  RAW -->|stage-all.sh| TAR[(Source0<br/>staging.tar.gz)]
+  YML[services.yaml] -->|render-systemd.sh| UNITS[systemd units]
+  TAR --> RPMBUILD
+  UNITS --> RPMBUILD
+  SPEC[specs/duynhlab.spec] --> RPMBUILD{{rpmbuild}}
+  RPMBUILD --> RPM[dist/duynhlab-VERSION.rpm]
+  RPM -->|publish-yum-repo.sh<br/>createrepo_c| REPO[gh-pages YUM repo]
+  REPO -->|dnf install| HOST[Target EL9 host]
+```
+
+## Repository layout
 
 ```
 packages/
-├── plan.md                  Refactor tracking document
-├── AGENTS.md                Repo conventions for agents/humans
-├── services.yaml            (Phase 1) Single source of truth for service list
-├── packaging/rpm/           (Phase 1) nFPM templates + systemd units
-├── scripts/                 (Phase 1) build-local.sh, build-rpm.sh, render-*.sh, duynhlab-ctl, duynhlab-db-setup
-├── .github/workflows/       (Phase 1-2) create-rpm-service, smoke-test, publish-yum-repo, orchestrator
-└── docs/                    (Phase 3) install / release-process / adding-service / troubleshooting
+├── services.yaml              Single source of truth (services, ports, DBs, deps)
+├── specs/duynhlab.spec        The one RPM spec (mega-RPM)
+├── scripts/                   Build / stage / publish / smoke pipeline
+│   ├── fetch-sources.sh         git clone every service repo
+│   ├── build-local.sh           compile one service from sibling checkout
+│   ├── render-systemd.sh        render units + target from services.yaml
+│   ├── stage-all.sh             assemble Source0 staging tarball
+│   ├── build-rpm.sh             rpmbuild (host/podman/docker)
+│   ├── publish-yum-repo.sh      createrepo_c -> gh-pages tree
+│   ├── smoke-install.sh         file-level install verification
+│   └── smoke-full.sh            full systemd smoke (podman + Postgres sidecar)
+├── packaging/
+│   ├── common/scripts/        CLI tools (duynhlab-ctl, duynhlab-db-setup, …)
+│   └── rpm/                    spec assets: scriptlets, systemd tmpl, nginx,
+│                              valkey, postgresql, logrotate, secret-tpl, lib
+├── .github/workflows/
+│   ├── build.yml              build-rpms (PR + push to main)
+│   ├── smoke-test-rpm.yml     full systemd smoke (manual / callable)
+│   └── publish-yum-repo.yml   build + publish to gh-pages (after build-rpms)
+└── docs/                      Documentation (see below)
 ```
 
-POC code (`sources/`, `Dockerfile`, `rpm/specs/`, legacy systemd) has been removed in Phase 0. To inspect history: `git checkout archive/poc-v0`.
+## Documentation
 
-## Getting started (after Phase 1)
+| Doc | Contents |
+|---|---|
+| [`docs/README.md`](docs/README.md) | Documentation index |
+| [`docs/install.md`](docs/install.md) | End-user install, bootstrap, upgrade, remove, troubleshooting |
+| [`docs/architecture.md`](docs/architecture.md) | Package layout, components, FHS map, lifecycle diagrams |
+| [`docs/build.md`](docs/build.md) | Build pipeline, scripts, Makefile, CI workflows |
+| [`docs/operations.md`](docs/operations.md) | `duynhlab-ctl`, `duynhlab-db-setup`, systemd targets, day-2 ops |
 
-```bash
-# Local-build a service from sibling repo checkout (~/Working/Me/duynhlab/<svc>-service)
-make build-local SERVICE=auth
+## Conventions
 
-# Then package
-make build SERVICE=auth VERSION=0.1.0-rc1
-ls dist/    # duynhlab-auth-0.1.0-rc1.el9.x86_64.rpm + duynhlab-common-*.rpm
-```
-
-See `plan.md` Phase 1 for the full pilot flow and `docs/install.md` (added in Phase 3) for end-user installation.
+- **Binary origin**: GitHub Release tarballs from `duynhlab/<svc>-service`; local fallback `build-local.sh` reads `$DUYNHLAB_SRC_ROOT/<svc>-service` (default `..`).
+- **FHS**: `/opt/duynhlab` immutable payload · `/etc/duynhlab` mutable state · journald-only logs.
+- **User**: `duynhlab:duynhlab`, system account, `nologin`.
+- **DB**: PostgreSQL ≥14, one database + `app`/`migrator` role per service. Migrations are **not** auto-run; units **not** auto-started.
+- **Secrets**: random 32-char `DB_PASSWORD` generated at `%post`, preserved on upgrade, never shipped as defaults.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,26 @@
+# duynhlab/packages documentation
+
+Distribution layer that repacks the upstream `duynhlab/*-service` binaries into a
+single **mega-RPM** and serves it from a YUM repository on GitHub Pages.
+
+Start with the repo [`README.md`](../README.md) for the high-level overview, then
+pick the guide that matches your task.
+
+## Index
+
+| Document | Audience | Contents |
+|---|---|---|
+| [`install.md`](install.md) | Operators installing the RPM | Add the repo, install, bootstrap the database, start, upgrade, remove, troubleshooting |
+| [`architecture.md`](architecture.md) | Anyone | Why a mega-RPM, component map, services table, FHS layout, systemd model, install/upgrade/remove lifecycle diagrams, database model |
+| [`build.md`](build.md) | Contributors / release engineers | Build pipeline, scripts, runner auto-detection, Makefile targets, CI workflows, gh-pages publishing, versioning, adding a service |
+| [`operations.md`](operations.md) | Operators (day-2) | `duynhlab-ctl` and `duynhlab-db-setup` reference, bring-up flow, systemd targets, configuration files, upgrade, remove, troubleshooting |
+
+## Conventions used in these docs
+
+- Diagrams are [Mermaid](https://mermaid.js.org/) and render natively on GitHub.
+- Service set: `auth user product cart order review notification shipping` (8
+  backends) plus the static `frontend`.
+- `duynhlab-db-setup` is **per-service** — every invocation takes one service
+  name (e.g. `duynhlab-db-setup migrate auth`).
+- Paths follow the FHS split: `/opt/duynhlab` (immutable payload) vs
+  `/etc/duynhlab` (mutable env/state, preserved across upgrades).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,201 @@
+# Architecture
+
+`duynhlab/packages` produces **one RPM** (a "mega-RPM") that contains the
+entire duynhlab platform. This document describes what is inside the package,
+where files land on disk, and the runtime lifecycle.
+
+---
+
+## 1. Why a single mega-RPM
+
+The platform is built from many independent `duynhlab/*-service` repos, but it
+is **deployed as a unit**. One package means:
+
+- Atomic upgrades — all backends move together, no version skew between them.
+- One dependency closure (`nginx`, `postgresql`, `valkey`/`redis`, `systemd`).
+- One `dnf install duynhlab` for operators.
+- A single SPEC ([`specs/duynhlab.spec`](../specs/duynhlab.spec)) instead of a
+  per-service build matrix.
+
+The trade-off (you cannot upgrade a single backend in isolation) is acceptable
+because the services share a release train.
+
+## 2. Components
+
+```mermaid
+flowchart TB
+  subgraph RPM["duynhlab-VERSION-1.el9.x86_64.rpm"]
+    direction TB
+    subgraph PAY["/opt/duynhlab  (immutable payload)"]
+      B["8 backends<br/>auth user product cart<br/>order review notification shipping"]
+      FE["frontend/dist (SPA)"]
+      LIB["lib/ — CLI tools + init-service.sh<br/>+ password-generator.sh"]
+      TPL["nginx · valkey · postgresql<br/>logrotate · secret-tpl templates"]
+      ETCMETA["etc/services.yaml<br/>etc/env-global.properties"]
+    end
+    UNITS["systemd units<br/>duynhlab-&lt;svc&gt;.service ×8<br/>duynhlab-platform.target<br/>duynhlab-infra.target"]
+    BIN["/usr/bin symlinks<br/>duynhlab-ctl, duynhlab-db-setup, …"]
+  end
+```
+
+| Component | Count | Notes |
+|---|---|---|
+| Backend services | 8 | Static Go binaries (`CGO_ENABLED=0`), one per `services.yaml` entry of `type: backend` |
+| Frontend | 1 | `type: static`, npm build output served by nginx |
+| CLI tools | 5 | `duynhlab-ctl`, `duynhlab-db-setup`, `duynhlab-db-migrate`, `duynhlab-gen-env`, `duynhlab-gen-password` |
+| systemd units | 8 + 2 targets | per-service `.service` + `duynhlab-platform.target` + `duynhlab-infra.target` |
+
+### Services (from `services.yaml`)
+
+| Service | Port | DB | Extra `After=` |
+|---|---|---|---|
+| auth | 8001 | `duynhlab_auth` | — |
+| user | 8002 | `duynhlab_user` | — |
+| product | 8003 | `duynhlab_product` | — |
+| cart | 8004 | `duynhlab_cart` | — |
+| order | 8005 | `duynhlab_order` | — |
+| review | 8006 | `duynhlab_review` | — |
+| notification | 8007 | `duynhlab_notification` | `valkey`/`redis` |
+| shipping | 8008 | `duynhlab_shipping` | — |
+| frontend | — | — | static, served by nginx |
+
+> `services.yaml` is the single source of truth. Adding a service there +
+> rebuilding regenerates units, the staging tree, and `duynhlab-ctl` output.
+
+## 3. Filesystem layout (FHS)
+
+```
+/opt/duynhlab/                      Immutable payload (owned by package)
+├── <svc>/
+│   ├── bin/<svc>-service           Backend binary
+│   ├── migrations/sql/             golang-migrate SQL files
+│   ├── BINARY_VERSION
+│   └── SCHEMA_VERSION              Schema the binary expects
+├── frontend/dist/                  Static SPA
+├── lib/                            CLI tools + init-service.sh + password-generator.sh
+├── nginx/ valkey/ postgresql/      Config templates (copied into /etc on install)
+├── logrotate/ secret-tpl/
+└── etc/
+    ├── services.yaml               Runtime copy read by CLI tools
+    └── env-global.properties       Shared env (DB host, etc.)
+
+/etc/duynhlab/                      Mutable state (NOT overwritten on upgrade)
+├── env-global.properties           Global overrides
+├── <svc>.env                       Per-service env incl. random DB_PASSWORD (0640)
+└── <svc>.override                  Optional operator override (EnvironmentFile=-)
+
+/usr/lib/systemd/system/            Units
+├── duynhlab-<svc>.service ×8
+├── duynhlab-platform.target
+└── duynhlab-infra.target
+
+/usr/bin/duynhlab-*                 Symlinks into /opt/duynhlab/lib
+
+/var/log/duynhlab/  /var/lib/duynhlab/    Log + state dirs
+```
+
+**Key principle**: `/opt/duynhlab` belongs to the package and is replaced on
+every upgrade; `/etc/duynhlab` belongs to the operator and survives upgrades
+and removal.
+
+## 4. systemd model
+
+```mermaid
+flowchart TB
+  MU[multi-user.target] --> PT[duynhlab-platform.target]
+  MU --> IT[duynhlab-infra.target]
+  PT -.Wants/After.-> IT
+  IT --> NG[nginx.service]
+  IT --> PG[postgresql.service]
+  IT --> VK[valkey.service]
+  PT --> S1[duynhlab-auth.service]
+  PT --> S2[duynhlab-user.service]
+  PT --> S3[duynhlab-…×6]
+  S1 -.After.-> IT
+  S2 -.After.-> IT
+  S3 -.After.-> IT
+```
+
+- **`duynhlab-infra.target`** — pulls in the external infra (`nginx`,
+  `postgresql`, `valkey`) via `Wants=`. Not owned/managed by us, just ordered.
+- **`duynhlab-platform.target`** — the operator entry point. `enable --now`
+  starts all backends.
+- Each **`duynhlab-<svc>.service`** is `PartOf=duynhlab-platform.target`,
+  ordered `After=duynhlab-infra.target`, runs as `duynhlab:duynhlab` with a
+  hardened sandbox (`ProtectSystem=strict`, `NoNewPrivileges`,
+  `MemoryDenyWriteExecute`, restricted syscalls/address families).
+
+Each unit loads, in order:
+
+```
+EnvironmentFile=-/etc/duynhlab/env-global.properties   # optional shared
+EnvironmentFile=/etc/duynhlab/<svc>.env                # required, has DB_PASSWORD
+EnvironmentFile=-/etc/duynhlab/<svc>.override          # optional operator
+```
+
+## 5. Install / upgrade / remove lifecycle
+
+```mermaid
+sequenceDiagram
+  participant dnf
+  participant rpm as RPM scriptlets
+  participant fs as Filesystem
+  participant sd as systemd
+
+  Note over dnf,sd: dnf install duynhlab  ($1 == 1)
+  dnf->>rpm: %pre
+  rpm->>fs: create duynhlab user/group (idempotent)
+  dnf->>fs: unpack /opt/duynhlab, units, /usr/bin symlinks
+  dnf->>rpm: %post
+  rpm->>fs: init-service.sh (drop nginx/valkey/logrotate configs)
+  rpm->>fs: password-generator.sh (random DB_PASSWORD per svc)
+  rpm->>sd: systemctl preset units (NOT start)
+  rpm-->>dnf: print "next steps" banner
+
+  Note over dnf,sd: dnf upgrade duynhlab  ($1 == 2)
+  dnf->>rpm: %pre
+  rpm->>sd: stop duynhlab-platform.target
+  dnf->>fs: replace /opt/duynhlab payload
+  dnf->>rpm: %post
+  rpm->>fs: init-service.sh (refresh templates)
+  Note right of rpm: env files preserved — no new passwords
+  rpm->>sd: daemon-reload
+
+  Note over dnf,sd: dnf remove duynhlab
+  dnf->>sd: stop + disable units
+  dnf->>fs: remove /opt/duynhlab + units
+  Note right of fs: /etc/duynhlab + Postgres data kept
+```
+
+What the scriptlets guarantee:
+
+- **First install only** generates passwords; upgrades never touch
+  `/etc/duynhlab/*.env`.
+- **No auto-start** — installing does not enable or start any unit.
+- **No auto-migrate** — the DB schema is the operator's responsibility via
+  `duynhlab-db-setup migrate`.
+- **No mutation of user-owned config** — nginx/valkey fragments are dropped
+  under `conf.d/`, never overwriting `nginx.conf`/`valkey.conf`.
+
+## 6. Database model
+
+Each backend owns one database and two roles (least privilege):
+
+```mermaid
+flowchart LR
+  subgraph PG[PostgreSQL ≥14]
+    DB[(duynhlab_&lt;svc&gt;)]
+    APP[duynhlab_&lt;svc&gt;_app<br/>CRUD only]
+    MIG[duynhlab_&lt;svc&gt;_migrator<br/>DDL]
+  end
+  RT[duynhlab-&lt;svc&gt;.service] -->|DB_PASSWORD<br/>app role| APP --> DB
+  MIGCLI[duynhlab-db-setup migrate] --> MIG --> DB
+```
+
+- `bootstrap` (needs `SUPERUSER_DSN`) creates the database + both roles + grants.
+- `migrate` applies `golang-migrate` files from
+  `/opt/duynhlab/<svc>/migrations/sql/` as the migrator role.
+- A backend refuses to start if the applied schema is older than its shipped
+  `SCHEMA_VERSION`.
+
+See [operations.md](operations.md) for the commands.

--- a/docs/build.md
+++ b/docs/build.md
@@ -1,0 +1,157 @@
+# Build & Release
+
+How a commit becomes an installable RPM in the YUM repo. The whole pipeline is
+driven by [`services.yaml`](../services.yaml) and produces a single
+`duynhlab-<VERSION>-1.el9.x86_64.rpm`.
+
+---
+
+## 1. Pipeline overview
+
+```mermaid
+flowchart TD
+  YML[services.yaml] --> FS[fetch-sources.sh]
+  FS -->|git clone/pull| SRC[(../&lt;svc&gt;-service)]
+  SRC --> BL[build-local.sh]
+  BL -->|go build / npm build<br/>+ tar + sha256| RAW[build/&lt;svc&gt;/raw/]
+  YML --> RS[render-systemd.sh]
+  RS --> UNITS[build/systemd/*.service<br/>+ duynhlab-platform.target]
+  RAW --> SA[stage-all.sh]
+  UNITS --> SA
+  SA -->|assemble FHS tree<br/>+ tar.gz| SRC0[(build/sources/<br/>duynhlab-VER-staging.tar.gz)]
+  SRC0 --> BR[build-rpm.sh]
+  SPEC[specs/duynhlab.spec] --> BR
+  BR -->|rpmbuild| RPM[dist/duynhlab-VER-1.el9.x86_64.rpm]
+  RPM --> SM[smoke-install.sh / smoke-full.sh]
+  RPM --> PUB[publish-yum-repo.sh]
+  PUB -->|createrepo_c| GH[gh-pages YUM repo]
+```
+
+## 2. Scripts
+
+All scripts live in [`scripts/`](../scripts) and source
+[`scripts/lib/common.sh`](../scripts/lib/common.sh) for shared helpers
+(`svc_field`, logging, `require_cmd`).
+
+| Script | Input | Output | Purpose |
+|---|---|---|---|
+| `fetch-sources.sh [ref]` | `services.yaml` | `$DUYNHLAB_SRC_ROOT/<svc>` | `git clone`/`pull` every service repo at `ref` (default `main`) |
+| `build-local.sh <svc> [ver]` | sibling checkout | `build/<svc>/raw/*.tar.gz` + `.sha256` | Compile one service (`CGO_ENABLED=0 GOOS=linux GOARCH=amd64`) or `npm build` for frontend; tar binary + migrations |
+| `render-systemd.sh [outdir]` | `services.yaml` + tmpl | `build/systemd/` | Render per-service `.service` + `duynhlab-platform.target` |
+| `stage-all.sh` | `build/*/raw/` + units | `build/sources/duynhlab-<ver>-staging.tar.gz` | Assemble the FHS payload tree → Source0 tarball |
+| `build-rpm.sh` | Source0 + spec | `dist/*.rpm` | `rpmbuild -ba specs/duynhlab.spec` |
+| `publish-yum-repo.sh` | `dist/*.rpm` | `build/gh-pages/` | `createrepo_c` + landing page + `duynhlab.repo` |
+| `smoke-install.sh` | `dist/*.rpm` | — | File-level install check in Rocky 9 |
+| `smoke-full.sh` | `dist/*.rpm` | — | Full systemd boot + health check (podman + Postgres) |
+
+### Runner auto-detection
+
+`build-rpm.sh` and `publish-yum-repo.sh` pick how to run `rpmbuild` /
+`createrepo_c`:
+
+```
+BUILD_RUNNER      = host | podman | docker   (build-rpm.sh)
+CREATEREPO_RUNNER = host | podman | docker   (publish-yum-repo.sh)
+```
+
+If unset, they prefer a host binary, then `podman`, then `docker`. Container
+builds use `rockylinux:9` (override with `BUILD_IMAGE`).
+
+## 3. Makefile
+
+```bash
+make help                     # list targets + show resolved env
+
+make fetch-sources REF=main   # clone/update all service repos
+make build-local SERVICE=auth # build a single service
+make build-local-all          # build every service in services.yaml
+make render-systemd           # render units only
+make stage                    # build Source0 staging tarball
+make build                    # stage + rpmbuild -> dist/
+make smoke                    # file-level install check
+make smoke-full               # full systemd smoke (podman + Postgres)
+make publish-repo             # stage gh-pages YUM tree
+make all                      # stage + build + smoke
+make clean                    # rm build/ dist/
+```
+
+Environment knobs:
+
+| Var | Default | Meaning |
+|---|---|---|
+| `VERSION` | `$(date -u +%Y.%m.%d)` | RPM version (CalVer) |
+| `DUYNHLAB_SRC_ROOT` | `..` (sibling dir) | Where service repos are cloned |
+| `BUILD_RUNNER` | auto | `host`/`podman`/`docker` for rpmbuild |
+| `SKIP_MIGRATE_DOWNLOAD` | unset | Skip golang-migrate fetch during stage |
+
+## 4. Local build walkthrough
+
+```bash
+# 0. (once) clone the service repos as siblings of this repo
+make fetch-sources
+
+# 1. compile binaries + frontend dist
+make build-local-all
+
+# 2. produce the RPM
+make build
+ls -lh dist/                 # duynhlab-2026.06.01-1.el9.x86_64.rpm
+
+# 3. verify it installs cleanly
+make smoke
+
+# 4. (optional) full boot test with a real Postgres + systemd
+make smoke-full              # needs podman with cgroup v2
+
+# 5. (optional) stage a local YUM mirror
+REPO_OUT=/tmp/duynhlab-repo BASE_URL=http://localhost:8080 \
+  ./scripts/publish-yum-repo.sh
+python3 -m http.server -d /tmp/duynhlab-repo 8080
+```
+
+## 5. CI workflows
+
+```mermaid
+flowchart LR
+  PR[PR / push to main] --> B[build-rpms]
+  B -->|success on main| P[publish-yum-repo]
+  P -->|createrepo_c| GH[(gh-pages)]
+  MAN1[workflow_dispatch] --> S[smoke-test-rpm]
+  MAN2[workflow_dispatch] --> P
+```
+
+| Workflow | File | Trigger | Does |
+|---|---|---|---|
+| **build-rpms** | [`build.yml`](../.github/workflows/build.yml) | PR + push to `main`, manual | fetch → build-local → render-systemd → **stage-all** → build-rpm → smoke-install → upload artefact |
+| **publish-yum-repo** | [`publish-yum-repo.yml`](../.github/workflows/publish-yum-repo.yml) | `workflow_run` after build-rpms on `main`, manual | rebuild RPM → `createrepo_c` → commit/push `gh-pages` |
+| **smoke-test-rpm** | [`smoke-test-rpm.yml`](../.github/workflows/smoke-test-rpm.yml) | manual, `workflow_call` | full systemd smoke in podman |
+
+> **Critical ordering**: `stage-all.sh` must run before `build-rpm.sh` — the
+> spec's `Source0` is the staging tarball. Every build workflow includes that
+> step.
+
+### Why gh-pages branch-push (not `deploy-pages` action)
+
+The YUM repo is an **append-only artefact store** that grows ~per release.
+`actions/upload-pages-artifact` caps at 1 GB and replaces the whole site each
+deploy, which breaks `createrepo_c --update` (it needs the previous repodata on
+disk). Branch-push keeps the repodata, gives a git audit trail, and can be
+force-reset to prune. If the tree ever exceeds ~1 GB, migrate to S3/R2 rather
+than the Pages artefact flow.
+
+## 6. Versioning
+
+- **Scheme**: CalVer `YYYY.MM.DD` (set `VERSION=` to override).
+- **Release tag**: `Release: 1%{?dist}` → `…-1.el9`.
+- `createrepo_c` dedupes by NVRA; rebuilding the same version overwrites
+  identical bits.
+
+## 7. Adding a new service
+
+1. Add an entry to [`services.yaml`](../services.yaml) (name, repo, port, type,
+   and `database` if it needs one).
+2. `make fetch-sources build-local-all build` — units, staging tree, and
+   `duynhlab-ctl` pick it up automatically.
+3. Update the hard-coded service loop in
+   [`specs/duynhlab.spec`](../specs/duynhlab.spec) `%check`/`%post` if the new
+   service is a backend (the spec lists the eight backends explicitly).

--- a/docs/install.md
+++ b/docs/install.md
@@ -80,20 +80,27 @@ The post-install scriptlet:
 
 ## 3. Bootstrap the database (one-time)
 
-Provide a PostgreSQL superuser DSN via `SUPERUSER_DSN` and let
-`duynhlab-db-setup` create one database + two roles per service (`app`,
-`migrator`), then apply migrations:
+`duynhlab-db-setup` is **per-service**: each invocation takes a single service
+name (`bootstrap <svc>` / `migrate <svc>`). It creates one database + two roles
+(`app`, `migrator`) for that service and stores the generated app-role password
+in `/etc/duynhlab/<svc>.env`.
+
+Provide a PostgreSQL superuser DSN via `SUPERUSER_DSN` and loop over the
+backend services:
 
 ```bash
-SUPERUSER_DSN="postgresql://postgres:secret@localhost:5432/postgres" \
-  sudo -E duynhlab-db-setup bootstrap
+export SUPERUSER_DSN="postgresql://postgres:secret@localhost:5432/postgres"
 
-sudo duynhlab-db-setup migrate
+for svc in auth user product cart order review notification shipping; do
+  sudo -E duynhlab-db-setup bootstrap "$svc"
+done
+
+for svc in auth user product cart order review notification shipping; do
+  sudo duynhlab-db-setup migrate "$svc"
+done
 ```
 
-`duynhlab-db-setup` reads `/etc/duynhlab/services.yaml` to know which services
-need a DB, and stores the generated app-role password in each
-`/etc/duynhlab/<svc>.env`.
+(`migrate` uses the migrator role and does not need `SUPERUSER_DSN`.)
 
 ## 4. Start the platform
 
@@ -115,7 +122,9 @@ journalctl -u 'duynhlab-*' -e --no-pager
 ```bash
 sudo dnf upgrade -y duynhlab
 # Apply any new migrations shipped in the new RPM:
-sudo duynhlab-db-setup migrate
+for svc in auth user product cart order review notification shipping; do
+  sudo duynhlab-db-setup migrate "$svc"
+done
 sudo systemctl restart duynhlab-platform.target
 ```
 
@@ -148,7 +157,7 @@ sudo -u postgres psql -c "DROP DATABASE duynhlab_auth;" ...
 | Symptom | Likely cause | Fix |
 |---|---|---|
 | `dnf install` fails: `Curl error (60): SSL certificate problem` | Mirror reach is restricted | `dnf install --setopt=sslverify=false` once, then fix CA |
-| `systemctl start duynhlab-auth` fails: "schema version mismatch" | Forgot `duynhlab-db-setup migrate` after upgrade | Run it, then restart |
+| `systemctl start duynhlab-auth` fails: "schema version mismatch" | Forgot `duynhlab-db-setup migrate auth` after upgrade | Run it, then restart |
 | `nginx -t` fails after install | Existing `nginx.conf` already defines `server { listen 80; }` | Edit `/etc/nginx/nginx.conf` to remove the default `server` block; ours lives in `conf.d/duynhlab.conf` |
 | `duynhlab-ctl status` shows `inactive (dead)` | DB unreachable or password wrong | `grep DB_PASSWORD /etc/duynhlab/<svc>.env`, verify via `psql` |
 
@@ -170,5 +179,6 @@ sudo curl -fsSL -o /etc/yum.repos.d/duynhlab.repo \
 sudo dnf install duynhlab
 ```
 
-See also: [`docs/release-process.md`](release-process.md) for the publish
-flow, and [`plan.md`](../plan.md) §2 for the broader Phase 2 design.
+See also: [`docs/README.md`](README.md) for the full documentation index —
+in particular [`build.md`](build.md) for the publish flow and
+[`operations.md`](operations.md) for day-2 operations.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,153 @@
+# Operations
+
+Day-2 operations for a host running the duynhlab platform: managing services,
+databases, and troubleshooting. All commands assume `root` (or `sudo`).
+
+---
+
+## 1. `duynhlab-ctl` — service control
+
+A thin, safe wrapper around `systemctl`/`journalctl` that knows the service
+list from `/etc/duynhlab/services.yaml`.
+
+```
+duynhlab-ctl <command> [svc|all] [args]
+```
+
+| Command | Example | Description |
+|---|---|---|
+| `list` | `duynhlab-ctl list` | List all services from `services.yaml` |
+| `status` | `duynhlab-ctl status all` | systemd status table |
+| `start` | `duynhlab-ctl start auth` | Start service(s) |
+| `stop` | `duynhlab-ctl stop all` | Stop service(s) |
+| `restart` | `duynhlab-ctl restart order` | Restart service(s) |
+| `enable` | `duynhlab-ctl enable all` | Enable on boot |
+| `disable` | `duynhlab-ctl disable user` | Disable on boot |
+| `logs` | `duynhlab-ctl logs auth -f` | Tail journal (extra args → `journalctl`) |
+| `health` | `duynhlab-ctl health all` | `curl /health` on each configured port |
+| `version` | `duynhlab-ctl version all` | Print binary + schema versions |
+| `config` | `duynhlab-ctl config auth` | Show env file (password masked) |
+| `ports` | `duynhlab-ctl ports` | Port assignment table |
+
+`svc` accepts a single name or `all`. Health/version iterate every service.
+
+## 2. `duynhlab-db-setup` — database management
+
+Operates **per service**. Reads connection settings from
+`/etc/duynhlab/<svc>.env`.
+
+```
+duynhlab-db-setup <bootstrap|migrate|status|rollback> <svc> [args]
+```
+
+| Subcommand | Needs | Description |
+|---|---|---|
+| `bootstrap <svc>` | `SUPERUSER_DSN` | Create database + `app`/`migrator` roles + grants |
+| `migrate <svc>` | — | Apply pending migrations as the migrator role |
+| `status <svc>` | — | Installed schema version vs shipped `SCHEMA_VERSION` |
+| `rollback <svc> <N>` | — | Roll back N migration steps (confirm prompt) |
+
+> There is **no `all`** target — bootstrap/migrate each service explicitly, or
+> loop in the shell.
+
+### One-time bootstrap (all backends)
+
+```bash
+export SUPERUSER_DSN="postgresql://postgres:secret@localhost:5432/postgres"
+for svc in auth user product cart order review notification shipping; do
+  duynhlab-db-setup bootstrap "$svc"
+  duynhlab-db-setup migrate   "$svc"
+done
+```
+
+`bootstrap` is idempotent: re-running will not recreate existing roles/DBs.
+The generated app password lives in each `/etc/duynhlab/<svc>.env`.
+
+## 3. Bringing the platform up
+
+```mermaid
+flowchart LR
+  I[dnf install duynhlab] --> B["db-setup bootstrap &lt;svc&gt;<br/>(per backend)"]
+  B --> M["db-setup migrate &lt;svc&gt;"]
+  M --> E[systemctl enable --now<br/>duynhlab-platform.target]
+  E --> V[duynhlab-ctl status / health]
+```
+
+```bash
+# after bootstrap + migrate:
+systemctl enable --now duynhlab-platform.target
+duynhlab-ctl status all
+duynhlab-ctl health all
+curl -fsS http://localhost/health
+```
+
+## 4. systemd targets
+
+| Unit | Purpose |
+|---|---|
+| `duynhlab-platform.target` | Operator entry point — starts all backends |
+| `duynhlab-infra.target` | Orders external infra (`nginx`, `postgresql`, `valkey`); does not own them |
+| `duynhlab-<svc>.service` | One per backend, `PartOf=` the platform target |
+
+```bash
+systemctl start  duynhlab-platform.target     # all backends
+systemctl status duynhlab-auth.service        # one backend
+systemctl restart duynhlab-platform.target    # rolling-ish restart
+journalctl -u 'duynhlab-*' -e --no-pager      # all logs
+```
+
+## 5. Configuration
+
+| File | Owner | Notes |
+|---|---|---|
+| `/etc/duynhlab/env-global.properties` | operator | Shared env (DB host, etc.), loaded first |
+| `/etc/duynhlab/<svc>.env` | package (1st install) | Per-service env incl. random `DB_PASSWORD`, `0640`, never overwritten on upgrade |
+| `/etc/duynhlab/<svc>.override` | operator | Optional last-wins overrides (`EnvironmentFile=-`) |
+
+To change a service's runtime setting without touching package files, write it
+to `<svc>.override` and `systemctl restart duynhlab-<svc>`.
+
+## 6. Upgrade
+
+```bash
+dnf upgrade -y duynhlab
+# apply any migrations shipped in the new payload, per backend:
+for svc in auth user product cart order review notification shipping; do
+  duynhlab-db-setup migrate "$svc"
+done
+systemctl restart duynhlab-platform.target
+```
+
+Upgrades preserve `/etc/duynhlab/*.env` and the database. A backend refuses to
+start if its binary expects a newer schema than is applied — run `migrate`
+first.
+
+## 7. Remove
+
+```bash
+systemctl disable --now duynhlab-platform.target
+dnf remove -y duynhlab
+```
+
+`dnf remove` deletes `/opt/duynhlab` and the units, but **keeps**
+`/etc/duynhlab` (env + passwords) and PostgreSQL data. Full purge:
+
+```bash
+rm -rf /etc/duynhlab /var/log/duynhlab /var/lib/duynhlab
+# and, deliberately:
+sudo -u postgres psql -c "DROP DATABASE duynhlab_auth;"   # … per service
+```
+
+## 8. Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `duynhlab-ctl status` shows `inactive (dead)` | DB unreachable / wrong password | `duynhlab-ctl config <svc>`, verify with `psql` |
+| Service fails: "schema version mismatch" | Forgot `migrate` after upgrade | `duynhlab-db-setup migrate <svc>`, restart |
+| `nginx -t` fails after install | Existing `server { listen 80; }` in `nginx.conf` | Remove the default server block; ours is in `conf.d/duynhlab.conf` |
+| `health` reports connection refused | Service not started or wrong port | `duynhlab-ctl start <svc>`; check `duynhlab-ctl ports` |
+| `db-setup bootstrap` errors `SUPERUSER_DSN` | Env var not exported | `export SUPERUSER_DSN=postgresql://postgres:…` |
+| `db-setup` errors `DB_PASSWORD empty` | Env file not generated | Reinstall, or run `duynhlab-gen-password` |
+
+See [install.md](install.md) for first-time setup and [architecture.md](architecture.md)
+for the systemd/DB model.


### PR DESCRIPTION
## Summary

- Standardize and expand the docs set around the mega-RPM model.
- Add `docs/architecture.md`, `docs/build.md`, `docs/operations.md` and a `docs/README.md` index, all with Mermaid diagrams.
- Rewrite `README.md` to drop outdated nFPM / per-service-RPM / phase-status content.
- Fix `docs/install.md`: `duynhlab-db-setup` is per-service (loop over the 8 backends instead of a bare `bootstrap`/`migrate`), and remove the dangling `release-process.md` / `plan.md` references.

## Test plan

- [ ] Render each doc on GitHub and confirm Mermaid diagrams display.
- [ ] Verify all relative doc links resolve.