### PR TITLE
fix(ci): force gh-pages branch before push in publish workflow

### DIFF
--- a/.github/workflows/publish-yum-repo.yml
+++ b/.github/workflows/publish-yum-repo.yml
@@ -58,7 +58,7 @@ jobs:
             git remote add origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
             : > .nojekyll
             git add .nojekyll
-            git -c user.email=ops@duynhlab.io -c user.name="duynhlab-ops" \
+            git -c user.email=duynebot@users.noreply.github.com -c user.name="duynebot" \
               commit -m "Initial gh-pages branch"
           fi
 
@@ -122,8 +122,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          git config user.email "ops@duynhlab.io"
-          git config user.name  "duynhlab-ops"
+          git config user.name  "duynebot"
+          git config user.email "duynebot@users.noreply.github.com"
           git remote set-url origin \
             "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
           # The repo may be on the runner's default branch (master) when gh-pages

--- a/.github/workflows/publish-yum-repo.yml
+++ b/.github/workflows/publish-yum-repo.yml
@@ -126,6 +126,10 @@ jobs:
           git config user.name  "duynhlab-ops"
           git remote set-url origin \
             "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+          # The repo may be on the runner's default branch (master) when gh-pages
+          # was freshly initialised. Force the working branch to gh-pages so the
+          # push refspec resolves in both the fresh-init and existing-branch cases.
+          git branch -M gh-pages
           git add -A
           if git diff --cached --quiet; then
             echo "No repo changes to publish"

--- a/README.md
+++ b/README.md
@@ -74,7 +74,59 @@ flowchart LR
   REPO -->|dnf install| HOST[Target EL9 host]
 ```
 
-## Repository layout
+## CI workflows
+
+Two GitHub Actions workflows split the pipeline into **validate** and **publish**.
+
+```mermaid
+flowchart LR
+  PR[Pull request] --> B
+  PUSH[Push to main] --> B
+  B[build-rpms<br/>build.yml] -->|on success<br/>workflow_run| P[publish-yum-repo<br/>publish-yum-repo.yml]
+  P --> PAGES[gh-pages YUM repo]
+```
+
+| Workflow | File | Triggers | What it does |
+|---|---|---|---|
+| `build-rpms` | [`build.yml`](.github/workflows/build.yml) | PR + push to `main`, `workflow_dispatch` | Build & smoke-test the mega-RPM |
+| `publish-yum-repo` | [`publish-yum-repo.yml`](.github/workflows/publish-yum-repo.yml) | After `build-rpms` succeeds on `main` (`workflow_run`), `workflow_dispatch` | Rebuild and publish the YUM repo to `gh-pages` |
+
+### `build-rpms` — validate on every change
+
+Runs on every PR and every push to `main`. It proves a change still produces an
+installable package **before** anything is published. Steps:
+
+1. Fetch every service source (`fetch-sources.sh`).
+2. Build all 8 backends + frontend (`build-local.sh` per service from `services.yaml`).
+3. Render systemd units (`render-systemd.sh`) and stage the Source0 tarball (`stage-all.sh`).
+4. Build the mega-RPM with `rpmbuild` in a Rocky 9 container (`build-rpm.sh`).
+5. **Smoke-install** the RPM inside Rocky 9 (`smoke-install.sh`) to catch scriptlet/dependency errors.
+6. Upload the RPM as a build artefact (kept 14 days).
+
+**Why it's needed:** it is the gate. It has `contents: read` only — it never
+publishes. A red `build-rpms` blocks the PR and prevents a broken RPM from ever
+reaching users.
+
+### `publish-yum-repo` — publish after a green build
+
+Triggered by `workflow_run` only when `build-rpms` finished **successfully on
+`main`** (so PRs never publish), or manually via `workflow_dispatch`. Steps:
+
+1. Check out `main` and the `gh-pages` branch (creating `gh-pages` if absent).
+2. Rebuild the mega-RPM (same pipeline as `build-rpms`).
+3. `publish-yum-repo.sh` runs `createrepo_c` to **incrementally update** the YUM
+   metadata into the `gh-pages` working tree.
+4. Commit and push `gh-pages`; GitHub Pages then serves
+   `https://duynhlab.github.io/packages`.
+
+**Why it's needed:** publishing is separated from validation so it only happens
+on trusted, merged code. It needs `contents: write` (push to `gh-pages`) and
+`pages: write`. The `[skip ci]` commit message and the success-on-`main`
+condition prevent an infinite build↔publish loop. Pushing a branch (rather than
+using the Pages artefact upload) is what lets `createrepo_c --update` keep older
+RPMs and only add new metadata.
+
+
 
 ```
 packages/


### PR DESCRIPTION
## Problem

Run [#26925986194](https://github.com/duynhlab/packages/actions/runs/26925986194) failed at **Commit + push gh-pages**:

```
[master (root-commit) 2051385] publish: ...
error: src refspec gh-pages does not match any
error: failed to push some refs
```

The `gh-pages` branch did not exist on the remote yet. `actions/checkout` (with `continue-on-error`) left the worktree on the runner default branch `master`, so the publish commit landed on `master` and `git push origin gh-pages` had nothing to push.

This is a workflow bug — **no GitHub repo setting change is required**.

## Fix

Add `git branch -M gh-pages` before commit/push so the working branch is always `gh-pages`, in both the fresh-init and existing-branch cases.

## Test plan

- [ ] Re-run `publish-yum-repo` and confirm the first publish creates and pushes `gh-pages`.
- [ ] Confirm Pages serves `https://duynhlab.github.io/packages/duynhlab.repo`.