### PR TITLE
ci: deploy YUM repo via actions/deploy-pages (hybrid)

### DIFF
--- a/.github/workflows/publish-yum-repo.yml
+++ b/.github/workflows/publish-yum-repo.yml
@@ -41,26 +41,12 @@ jobs:
         with:
           path: packages
 
-      - name: Checkout gh-pages (will be created if missing)
+      - name: Checkout gh-pages
         uses: actions/checkout@v6
         with:
           ref: gh-pages
           path: gh-pages
           fetch-depth: 1
-        continue-on-error: true
-
-      - name: Initialise gh-pages branch if absent
-        run: |
-          if [ ! -d gh-pages/.git ]; then
-            mkdir -p gh-pages
-            cd gh-pages
-            git init -b gh-pages
-            git remote add origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
-            : > .nojekyll
-            git add .nojekyll
-            git -c user.email=duynebot@users.noreply.github.com -c user.name="duynebot" \
-              commit -m "Initial gh-pages branch"
-          fi
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -116,7 +102,7 @@ jobs:
           BASE_URL: ${{ env.BASE_URL }}
         run: ./scripts/publish-yum-repo.sh
 
-      - name: Commit + push gh-pages
+      - name: Commit + push gh-pages (durable accumulator)
         working-directory: gh-pages
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -126,20 +112,38 @@ jobs:
           git config user.email "duynebot@users.noreply.github.com"
           git remote set-url origin \
             "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
-          # The repo may be on the runner's default branch (master) when gh-pages
-          # was freshly initialised. Force the working branch to gh-pages so the
-          # push refspec resolves in both the fresh-init and existing-branch cases.
-          git branch -M gh-pages
           git add -A
           if git diff --cached --quiet; then
             echo "No repo changes to publish"
-            exit 0
+          else
+            git commit -m "publish: $(date -u +%Y-%m-%dT%H:%M:%SZ) [skip ci]"
+            git push origin gh-pages
           fi
-          git commit -m "publish: $(date -u +%Y-%m-%dT%H:%M:%SZ) [skip ci]"
-          git push origin gh-pages
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v6
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: gh-pages
+          include-hidden-files: true
 
       - name: Print final URLs
         run: |
           echo "Repo:       $BASE_URL"
           echo ".repo file: $BASE_URL/duynhlab.repo"
           echo "RPMs:       $BASE_URL/rpm/el9/x86_64/"
+
+  deploy:
+    name: Deploy gh-pages tree to GitHub Pages
+    needs: build-and-publish
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5
+

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ flowchart LR
 | Workflow | File | Triggers | What it does |
 |---|---|---|---|
 | `build-rpms` | [`build.yml`](.github/workflows/build.yml) | PR + push to `main`, `workflow_dispatch` | Build & smoke-test the mega-RPM |
-| `publish-yum-repo` | [`publish-yum-repo.yml`](.github/workflows/publish-yum-repo.yml) | After `build-rpms` succeeds on `main` (`workflow_run`), `workflow_dispatch` | Rebuild and publish the YUM repo to `gh-pages` |
+| `publish-yum-repo` | [`publish-yum-repo.yml`](.github/workflows/publish-yum-repo.yml) | After `build-rpms` succeeds on `main` (`workflow_run`), `workflow_dispatch` | Accumulate the YUM repo on `gh-pages`, then deploy it via `actions/deploy-pages` |
 
 ### `build-rpms` — validate on every change
 
@@ -112,19 +112,26 @@ reaching users.
 Triggered by `workflow_run` only when `build-rpms` finished **successfully on
 `main`** (so PRs never publish), or manually via `workflow_dispatch`. Steps:
 
-1. Check out `main` and the `gh-pages` branch (creating `gh-pages` if absent).
+1. Check out `main` and the persistent `gh-pages` branch.
 2. Rebuild the mega-RPM (same pipeline as `build-rpms`).
 3. `publish-yum-repo.sh` runs `createrepo_c` to **incrementally update** the YUM
-   metadata into the `gh-pages` working tree.
-4. Commit and push `gh-pages`; GitHub Pages then serves
+   metadata into the `gh-pages` working tree (old RPMs + new RPM).
+4. Commit and push `gh-pages` — the **durable accumulator** that retains every
+   previously published RPM.
+5. Upload that tree as a Pages artifact and deploy it with
+   `actions/deploy-pages`; GitHub then serves
    `https://duynhlab.github.io/packages`.
 
-**Why it's needed:** publishing is separated from validation so it only happens
-on trusted, merged code. It needs `contents: write` (push to `gh-pages`) and
-`pages: write`. The `[skip ci]` commit message and the success-on-`main`
-condition prevent an infinite build↔publish loop. Pushing a branch (rather than
-using the Pages artefact upload) is what lets `createrepo_c --update` keep older
-RPMs and only add new metadata.
+**Why both a branch and the Pages artifact?** GitHub's artifact-based Pages
+deploy (`deploy-pages`) **fully replaces** the site on every run — it has no
+incremental mode. A YUM repo is incremental: `createrepo_c --update` must see
+the previously published RPMs to re-index them. So the `gh-pages` branch is the
+source of truth that *accumulates* RPMs across runs, and each deploy simply
+serves the full current tree from that branch. Validation is also separated
+from publishing (only merged `main` publishes); the `[skip ci]` commit message
+and the success-on-`main` condition prevent an infinite build↔publish loop. The
+job needs `contents: write` (push `gh-pages`), `pages: write`, and `id-token:
+write` (deploy).
 
 
 


### PR DESCRIPTION
## Summary

Switch the Pages serving layer to the official GitHub Actions deploy path (`configure-pages` → `upload-pages-artifact` → `deploy-pages`), while **keeping the `gh-pages` branch** as the durable, incremental store.

## Why hybrid (branch + artifact)

`actions/deploy-pages` **fully replaces** the published site on every run — it has no incremental/additive mode (max ~1GB artifact). A YUM repo is incremental: `createrepo_c --update` must see previously published RPMs to re-index them. So:

- `gh-pages` branch = **durable accumulator** (every RPM ever published).
- Each run: checkout `gh-pages` → `createrepo_c --update` (old + new) → commit/push branch → upload that tree as the Pages artifact → `deploy-pages` serves it.

## Changes

- New `deploy` job using `actions/deploy-pages@v5` with the `github-pages` environment.
- `configure-pages@v6` + `upload-pages-artifact@v5` (`include-hidden-files: true` to keep `.nojekyll`).
- Remove the obsolete *Initialise gh-pages branch if absent* step and the `git branch -M` hack (branch now created once and persists).
- README: document the hybrid model and why artifact-only deploy is insufficient for a YUM repo.

## Required one-time setting

**Settings → Pages → Source = "GitHub Actions"** (the screenshot option). `enablement` is left `false` because it requires a non-`GITHUB_TOKEN` credential.

## Test plan

- [ ] Set Pages Source = GitHub Actions.
- [ ] Run `publish-yum-repo`; confirm branch push + `deploy` job succeed and the site serves `duynhlab.repo` and `rpm/el9/x86_64/`.