### PR TITLE
ci: host RPMs on GitHub Releases (metadata-only gh-pages)

### DIFF
--- a/.github/workflows/publish-yum-repo.yml
+++ b/.github/workflows/publish-yum-repo.yml
@@ -89,20 +89,45 @@ jobs:
         working-directory: packages
         run: ./scripts/stage-all.sh
 
+      - name: Compute version
+        id: ver
+        run: echo "version=$(date -u +%Y.%m.%d)" >> "$GITHUB_OUTPUT"
+
       - name: Build mega-RPM
         working-directory: packages
         env:
           BUILD_RUNNER: docker
+          VERSION: ${{ steps.ver.outputs.version }}
         run: ./scripts/build-rpm.sh
+
+      - name: Create GitHub Release + upload RPM
+        working-directory: packages
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          set -euo pipefail
+          tag="v${VERSION}"
+          rpm=$(ls dist/duynhlab-*.x86_64.rpm | head -1)
+          echo "Release tag: $tag  asset: $rpm"
+          if gh release view "$tag" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            gh release upload "$tag" "$rpm" --repo "${{ github.repository }}" --clobber
+          else
+            gh release create "$tag" "$rpm" \
+              --repo "${{ github.repository }}" \
+              --title "duynhlab ${VERSION}" \
+              --notes "Mega-RPM for the duynhlab platform (EL9). Install via the YUM repo: https://duynhlab.github.io/packages"
+          fi
 
       - name: Stage YUM repo into gh-pages tree
         working-directory: packages
         env:
           REPO_OUT: ${{ github.workspace }}/gh-pages
           BASE_URL: ${{ env.BASE_URL }}
+          RELEASE_BASE_URL: https://github.com/${{ github.repository }}/releases/download/v${{ steps.ver.outputs.version }}/
         run: ./scripts/publish-yum-repo.sh
 
-      - name: Commit + push gh-pages (durable accumulator)
+      - name: Commit + push gh-pages (orphan, metadata only)
         working-directory: gh-pages
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -112,13 +137,13 @@ jobs:
           git config user.email "duynebot@users.noreply.github.com"
           git remote set-url origin \
             "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+          # gh-pages now holds only repodata + landing files (KB-sized), so keep a
+          # single-commit orphan branch — no history bloat, no large-file pushes.
+          git checkout --orphan publish
           git add -A
-          if git diff --cached --quiet; then
-            echo "No repo changes to publish"
-          else
-            git commit -m "publish: $(date -u +%Y-%m-%dT%H:%M:%SZ) [skip ci]"
-            git push origin gh-pages
-          fi
+          git commit -m "publish: $(date -u +%Y-%m-%dT%H:%M:%SZ) [skip ci]"
+          git branch -M publish gh-pages
+          git push -f origin gh-pages
 
       - name: Configure Pages
         uses: actions/configure-pages@v6
@@ -133,7 +158,8 @@ jobs:
         run: |
           echo "Repo:       $BASE_URL"
           echo ".repo file: $BASE_URL/duynhlab.repo"
-          echo "RPMs:       $BASE_URL/rpm/el9/x86_64/"
+          echo "Metadata:   $BASE_URL/rpm/el9/x86_64/repodata/"
+          echo "RPMs:       https://github.com/${{ github.repository }}/releases/tag/v${{ steps.ver.outputs.version }}"
 
   deploy:
     name: Deploy gh-pages tree to GitHub Pages

--- a/docs/build.md
+++ b/docs/build.md
@@ -133,7 +133,8 @@ python3 -m http.server -d /tmp/duynhlab-repo 8080
 flowchart LR
   PR[PR / push to main] --> B[build-rpms]
   B -->|success on main| P[publish-yum-repo]
-  P -->|createrepo_c| GH[(gh-pages)]
+  P -->|gh release upload| REL[(GitHub Release<br/>RPM asset)]
+  P -->|createrepo_c --location-prefix| GH[(gh-pages<br/>repodata only)]
   MAN1[workflow_dispatch] --> S[smoke-test-rpm]
   MAN2[workflow_dispatch] --> P
 ```
@@ -141,21 +142,43 @@ flowchart LR
 | Workflow | File | Trigger | Does |
 |---|---|---|---|
 | **build-rpms** | [`build.yml`](../.github/workflows/build.yml) | PR + push to `main`, manual | fetch → build-local → render-systemd → **stage-all** → build-rpm → smoke-install → upload artefact |
-| **publish-yum-repo** | [`publish-yum-repo.yml`](../.github/workflows/publish-yum-repo.yml) | `workflow_run` after build-rpms on `main`, manual | rebuild RPM → `createrepo_c` → commit/push `gh-pages` |
+| **publish-yum-repo** | [`publish-yum-repo.yml`](../.github/workflows/publish-yum-repo.yml) | `workflow_run` after build-rpms on `main`, manual | rebuild RPM → **`gh release create v<VER>` + upload RPM** → `createrepo_c --location-prefix <release-url>` → force-push orphan `gh-pages` (repodata only) → `deploy-pages` |
 | **smoke-test-rpm** | [`smoke-test-rpm.yml`](../.github/workflows/smoke-test-rpm.yml) | manual, `workflow_call` | full systemd smoke in podman |
 
 > **Critical ordering**: `stage-all.sh` must run before `build-rpm.sh` — the
 > spec's `Source0` is the staging tarball. Every build workflow includes that
 > step.
 
-### Why gh-pages branch-push (not `deploy-pages` action)
+### Where the RPMs live: GitHub Releases, not gh-pages
 
-The YUM repo is an **append-only artefact store** that grows ~per release.
-`actions/upload-pages-artifact` caps at 1 GB and replaces the whole site each
-deploy, which breaks `createrepo_c --update` (it needs the previous repodata on
-disk). Branch-push keeps the repodata, gives a git audit trail, and can be
-force-reset to prune. If the tree ever exceeds ~1 GB, migrate to S3/R2 rather
-than the Pages artefact flow.
+The mega-RPM is ~70–80 MB and grows per release. Committing it to a git branch
+is a dead end: GitHub hard-rejects any file >100 MB (`pre-receive hook
+declined`) and accumulating 80 MB blobs across releases bloats history until the
+repo hits its size cap.
+
+So the RPM payload is hosted as a **GitHub Release asset** (2 GB per-file
+limit), and `gh-pages` carries **only the YUM metadata**:
+
+```
+GitHub Release  v<VER>/duynhlab-<VER>-1.el9.x86_64.rpm     (the actual package)
+gh-pages        rpm/el9/x86_64/repodata/*                  (KB of metadata)
+                duynhlab.repo, index.html, README.md
+```
+
+`createrepo_c --location-prefix
+https://github.com/duynhlab/packages/releases/download/v<VER>/` writes the
+metadata's `<location href>` as an **absolute URL** to the release asset, so
+`dnf` reads metadata from Pages and downloads the RPM straight from Releases.
+
+Because gh-pages is now KB-sized, it is force-pushed as a **single-commit orphan
+branch** each run — no large-file pushes, no history bloat. Release history (and
+rollback) is preserved on the Releases page itself, keyed by the `v<VER>` tag.
+
+`actions/deploy-pages` then publishes the gh-pages tree (it replaces the whole
+site each deploy, which is fine because the metadata is fully regenerated every
+run). Local `make publish-repo` runs without `RELEASE_BASE_URL`, falling back to
+the self-contained model (RPMs copied into the tree) so the repo is servable
+from `python3 -m http.server`.
 
 ## 6. Versioning
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -40,7 +40,25 @@ All scripts live in [`scripts/`](../scripts) and source
 | `render-systemd.sh [outdir]` | `services.yaml` + tmpl | `build/systemd/` | Render per-service `.service` + `duynhlab-platform.target` |
 | `stage-all.sh` | `build/*/raw/` + units | `build/sources/duynhlab-<ver>-staging.tar.gz` | Assemble the FHS payload tree → Source0 tarball |
 | `build-rpm.sh` | Source0 + spec | `dist/*.rpm` | `rpmbuild -ba specs/duynhlab.spec` |
-| `publish-yum-repo.sh` | `dist/*.rpm` | `build/gh-pages/` | `createrepo_c` + landing page + `duynhlab.repo` |
+| `publish-yum-repo.sh` | `dist/*.x86_64.rpm` | `build/gh-pages/` | `createrepo_c` + landing page + `duynhlab.repo` |
+
+> **Why no SRPMs are published**: `rpmbuild -ba` also emits a source RPM
+> (`dist/*.src.rpm`), but `publish-yum-repo.sh` only publishes the binary
+> `*.x86_64.rpm`. An SRPM is the *source bundle* (code + spec + patches) used to
+> `rpmbuild --rebuild` a binary — it is **not** installable and `dnf install`
+> never needs it. Reasons it is dropped:
+>
+> - **Not needed**: this is a binary-only YUM repo; clients only consume the
+>   `.x86_64.rpm`.
+> - **Redundant**: the real source lives in the upstream
+>   `duynhlab/<svc>-service` repos; the SRPM is just a fat copy of all eight
+>   services + frontend (~86 MB).
+> - **Breaks publishing**: at ~103 MB it exceeds GitHub's hard **100 MB
+>   per-file** limit, so pushing it to `gh-pages` is rejected
+>   (`pre-receive hook declined`).
+>
+> Keep SRPMs only if you ever distribute via Fedora/EPEL or must ship source for
+> compliance — neither applies here.
 | `smoke-install.sh` | `dist/*.rpm` | — | File-level install check in Rocky 9 |
 | `smoke-full.sh` | `dist/*.rpm` | — | Full systemd boot + health check (podman + Postgres) |
 

--- a/scripts/publish-yum-repo.sh
+++ b/scripts/publish-yum-repo.sh
@@ -27,6 +27,16 @@ ARCH_DIR="rpm/el9/x86_64"
 BASE_URL="${BASE_URL:-https://duynhlab.github.io/packages}"
 PAGES_HOST="${PAGES_HOST:-duynhlab.github.io}"
 
+# RELEASE_BASE_URL — when set, RPM payloads live as GitHub Release assets and
+# only the repodata is published to gh-pages. createrepo_c writes absolute
+# <location href> entries pointing at the release download URL, so the gh-pages
+# arch dir never holds an .rpm (avoids the 100 MB git file limit + history bloat).
+# Must end with a trailing slash, e.g.
+#   https://github.com/duynhlab/packages/releases/download/v2026.06.04/
+# When unset, the script falls back to the local model (RPMs copied into the
+# tree) so `make publish-repo` still produces a self-contained, servable repo.
+RELEASE_BASE_URL="${RELEASE_BASE_URL:-}"
+
 shopt -s nullglob
 rpms=( "$RPM_SRC"/*.x86_64.rpm "$RPM_SRC"/*.noarch.rpm )
 [[ ${#rpms[@]} -gt 0 ]] || die "No RPMs in $RPM_SRC — run scripts/build-rpm.sh first"
@@ -34,13 +44,24 @@ rpms=( "$RPM_SRC"/*.x86_64.rpm "$RPM_SRC"/*.noarch.rpm )
 log_info "RPM_SRC=$RPM_SRC  (${#rpms[@]} files)"
 log_info "REPO_OUT=$REPO_OUT"
 
+# createrepo_c always runs over a self-contained input dir holding the RPMs.
+# In release mode that's a scratch dir (RPMs discarded after metadata is built);
+# in local mode it's the published arch dir itself.
 mkdir -p "$REPO_OUT/$ARCH_DIR"
+if [[ -n "$RELEASE_BASE_URL" ]]; then
+  [[ "$RELEASE_BASE_URL" == */ ]] || RELEASE_BASE_URL="$RELEASE_BASE_URL/"
+  CR_INPUT="$BUILD_DIR/createrepo-input"
+  rm -rf "$CR_INPUT"; mkdir -p "$CR_INPUT"
+  log_info "RELEASE mode — RPMs served from $RELEASE_BASE_URL"
+else
+  CR_INPUT="$REPO_OUT/$ARCH_DIR"
+  log_info "LOCAL mode — RPMs copied into $CR_INPUT"
+fi
 
-# Copy fresh RPMs in (overwrite — same NVRA produces identical bits).
 for r in "${rpms[@]}"; do
-  cp -f "$r" "$REPO_OUT/$ARCH_DIR/"
+  cp -f "$r" "$CR_INPUT/"
 done
-log_ok "copied ${#rpms[@]} RPM(s) into $REPO_OUT/$ARCH_DIR"
+log_ok "staged ${#rpms[@]} RPM(s) into $CR_INPUT"
 
 # SRPMs are intentionally NOT published: the .src.rpm exceeds GitHub's 100 MB
 # per-file limit and is not needed for `dnf install` of a binary repo.
@@ -61,23 +82,30 @@ fi
 
 log_step "createrepo_c (runner=$runner)"
 
+# In release mode createrepo runs fresh on a scratch dir (no prior repodata),
+# so --update is a no-op there; in local mode --update reuses cached checksums.
+cr_args=( --update )
+[[ -n "$RELEASE_BASE_URL" ]] && cr_args=( --location-prefix "$RELEASE_BASE_URL" )
+
 run_host_createrepo() {
-  createrepo_c --update "$REPO_OUT/$ARCH_DIR"
+  createrepo_c "${cr_args[@]}" "$CR_INPUT"
 }
 
 run_container_createrepo() {
   local rt=$1 sel=""
   [[ "$rt" == "podman" ]] && sel=":Z"
   "$rt" run --rm \
-    -v "$REPO_OUT:/repo${sel}" \
-    -w /repo \
+    -v "$CR_INPUT:/cr_input${sel}" \
+    -e HOST_UID="$(id -u)" -e HOST_GID="$(id -g)" \
+    -w / \
     rockylinux:9 \
     bash -c '
       set -e
       if ! command -v createrepo_c >/dev/null 2>&1; then
         dnf -y install --setopt=install_weak_deps=False createrepo_c >/dev/null
       fi
-      createrepo_c --update '"$ARCH_DIR"'
+      createrepo_c '"${cr_args[*]}"' /cr_input
+      chown -R "${HOST_UID}:${HOST_GID}" /cr_input/repodata 2>/dev/null || true
     '
 }
 
@@ -87,7 +115,25 @@ case "$runner" in
   *) die "Unknown CREATEREPO_RUNNER: $runner" ;;
 esac
 
+# In release mode, move only the freshly built repodata into the published tree
+# (replace any stale repodata; the arch dir must stay .rpm-free, so also purge
+# any leftover RPMs from an earlier accumulator-branch checkout).
+if [[ -n "$RELEASE_BASE_URL" ]]; then
+  rm -f "$REPO_OUT/$ARCH_DIR"/*.rpm
+  rm -rf "$REPO_OUT/$ARCH_DIR/repodata"
+  mkdir -p "$REPO_OUT/$ARCH_DIR"
+  cp -rf "$CR_INPUT/repodata" "$REPO_OUT/$ARCH_DIR/repodata"
+  rm -rf "$CR_INPUT"
+fi
+
 log_ok "repodata generated: $REPO_OUT/$ARCH_DIR/repodata/repomd.xml"
+
+# Link used on the landing page's "Browse" list.
+if [[ -n "$RELEASE_BASE_URL" ]]; then
+  RELEASE_LINK="$RELEASE_BASE_URL"
+else
+  RELEASE_LINK="rpm/el9/x86_64/"
+fi
 
 # ── Landing files (root of gh-pages) ──────────────────────────────────────────
 cat > "$REPO_OUT/duynhlab.repo" <<EOF
@@ -121,7 +167,8 @@ sudo systemctl enable --now duynhlab-platform.target</pre>
 
 <h2>Browse</h2>
 <ul>
-  <li><a href="rpm/el9/x86_64/">rpm/el9/x86_64/</a></li>
+  <li><a href="$RELEASE_LINK">RPM downloads (GitHub Releases)</a></li>
+  <li><a href="rpm/el9/x86_64/repodata/">rpm/el9/x86_64/repodata/</a> (metadata)</li>
   <li><a href="duynhlab.repo">duynhlab.repo</a></li>
 </ul>
 EOF


### PR DESCRIPTION
## Summary
- Host the mega-RPM as a **GitHub Release asset** (tag `v<VER>`, 2 GB/file limit) instead of committing it to `gh-pages`. The RPM is ~70–80 MB and grows per release; GitHub rejects files >100 MB and accumulating large blobs on a branch bloats history.
- `publish-yum-repo.sh` gains a `RELEASE_BASE_URL` mode: `createrepo_c --location-prefix <release-url>` writes **absolute** `<location href>` entries, and only `repodata/` + landing files are staged into `gh-pages` (no `.rpm`).
- `gh-pages` is force-pushed as a **single-commit orphan branch** (KB-sized) — no history bloat. Release history / rollback lives on the Releases page.
- Without `RELEASE_BASE_URL`, the script keeps the self-contained local model so `make publish-repo` still serves a complete repo.
- Also drops SRPM publishing (carried from merged #22) and documents the model in `docs/build.md`.

## How dnf still works
`baseurl` on the client is unchanged (`…/rpm/el9/$basearch/`). dnf reads metadata from Pages, then downloads the RPM from the absolute Release URL baked into the metadata.

## Test plan
- [x] `publish-yum-repo.sh` release mode tested locally (docker createrepo_c): gh-pages tree contains only `repodata/`, `<location href>` is the absolute Release URL, no `.rpm` present
- [ ] `publish-yum-repo` workflow: creates release `v<VER>`, uploads RPM, force-pushes orphan gh-pages, deploy-pages succeeds
- [ ] `dnf install duynhlab` pulls RPM from Releases