### PR TITLE
fix(systemd): make infra.target a real ordering barrier; unify valkey

### DIFF
--- a/packaging/rpm/systemd/duynhlab-infra.target
+++ b/packaging/rpm/systemd/duynhlab-infra.target
@@ -1,7 +1,10 @@
 [Unit]
 Description=duynhlab external infrastructure (nginx, valkey, postgresql)
 Documentation=https://duynhlab.github.io/packages
-After=network-online.target
+# After= makes this target a real synchronization barrier: it is only reached
+# once nginx/postgresql/valkey have finished starting, so duynhlab backends
+# (which order After=duynhlab-infra.target) never race ahead of the database.
+After=network-online.target nginx.service postgresql.service valkey.service
 Wants=network-online.target
 Wants=nginx.service
 Wants=postgresql.service

--- a/services.yaml
+++ b/services.yaml
@@ -116,8 +116,8 @@ services:
       app_user: duynhlab_notification_app
       migrator_user: duynhlab_notification_migrator
     dependencies:
-      after: [redis.service]
-      env_files: [/etc/duynhlab/common/redis.properties]
+      after: [valkey.service]
+      env_files: [/etc/duynhlab/common/valkey.properties]
 
   - name: shipping
     repo: duynhlab/shipping-service


### PR DESCRIPTION
## Problem
The 8 backend services order `After=duynhlab-infra.target`, expecting infra (nginx/postgres/valkey) to be up first. But `duynhlab-infra.target` only declared `Wants=` for those units — **no `After=`** — so the target was considered reached as soon as they were *queued*, not *started*. Backends could launch while PostgreSQL was still initializing → connection failures on boot (masked only by `Restart=on-failure` retries).

Separately, `services.yaml` had `notification` depending on `redis.service` / `redis.properties`, but EL9 ships **valkey** and `infra.target` orders `valkey.service`. The `After=redis.service` ref resolved to a non-existent unit (silently ignored).

## Fix
- **`duynhlab-infra.target`**: add `After=nginx.service postgresql.service valkey.service` → the target is now a real synchronization barrier. Backends only start once infra has finished starting.
- **`services.yaml`**: notification `after`/`env_files` → `valkey.service` / `valkey.properties`.

## Design notes
- Kept **`Wants=` (soft), not `Requires=`**: a `systemctl restart postgresql` should not cascade-restart all 8 backends. Services reconnect via app retry + `Restart=on-failure`. This is the resilient/cloud-native ordering.
- `frontend` (`type: static`) correctly renders no unit — it is served by nginx. Verified `render-systemd.sh` skips it.
- App-level `REDIS_HOST/REDIS_PORT` env vars are intentionally unchanged (Valkey is wire-compatible; that's the app contract, not a unit name).

## Test plan
- [x] `render-systemd.sh` produces `infra.target` with `After=...valkey.service` and notification with `After=...valkey.service` + `valkey.properties`
- [ ] smoke-full boots `duynhlab-platform.target` with infra ordered first