### PR TITLE
ci: name release 'packages <VER>'

### DIFF
--- a/.github/workflows/publish-yum-repo.yml
+++ b/.github/workflows/publish-yum-repo.yml
@@ -115,7 +115,7 @@ jobs:
           else
             gh release create "$tag" "$rpm" \
               --repo "${{ github.repository }}" \
-              --title "duynhlab ${VERSION}" \
+              --title "packages ${VERSION}" \
               --notes "Mega-RPM for the duynhlab platform (EL9). Install via the YUM repo: https://duynhlab.github.io/packages"
           fi
 


### PR DESCRIPTION
## Summary
- The `publish-yum-repo` workflow created releases titled `duynhlab <VER>`. Rename the auto-generated title to `packages <VER>` to match the repository name.
- Tag (`v<VER>`) and asset filename are unchanged.

The existing `v2026.06.04` release was already manually renamed; this makes future runs consistent.