### PR TITLE
ci: run smoke-full rootless, keep pod for diagnostics

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,25 +141,31 @@ jobs:
 
       # smoke-full.sh boots a systemd container; the default centos:stream9 image is
       # minimal and has NO /sbin/init — build a systemd-capable image first.
-      # Built with sudo because smoke-full.sh runs under sudo (root podman storage).
+      # Everything runs ROOTLESS: root podman + systemd-in-container breaks on the
+      # ubuntu runners ("systemd did not start", run 27274677129), while the rootless
+      # path is the one validated end-to-end. Same user for build + run = same storage.
       - name: Build systemd-capable app image
         run: |
-          sudo podman build -t localhost/duynhlab-smoke-init:latest -f - . <<'EOF'
+          podman build -t localhost/duynhlab-smoke-init:latest -f - . <<'EOF'
           FROM quay.io/centos/centos:stream9
           RUN dnf -y install systemd && dnf clean all
           EOF
 
+      # KEEP_POD=1: smoke-full.sh's cleanup trap would otherwise remove the pod on
+      # failure, leaving the journal-dump step below with nothing to inspect. The
+      # runner is ephemeral, so skipping cleanup is free.
       - name: Full smoke (systemd + Postgres)
         working-directory: packages
         env:
           APP_IMAGE: localhost/duynhlab-smoke-init:latest
-        run: sudo -E ./scripts/smoke-full.sh
+          KEEP_POD: "1"
+        run: ./scripts/smoke-full.sh
 
       - name: Dump app journal on failure
         if: failure()
         run: |
           set +e
-          sudo podman ps -a
-          sudo podman logs duynhlab-smoke-app    | tail -300 || true
-          sudo podman logs duynhlab-smoke-db     | tail -100 || true
-          sudo podman exec duynhlab-smoke-app journalctl -xe --no-pager | tail -500 || true
+          podman ps -a
+          podman logs duynhlab-smoke-app    | tail -300 || true
+          podman logs duynhlab-smoke-db     | tail -100 || true
+          podman exec duynhlab-smoke-app journalctl -xe --no-pager | tail -500 || true

--- a/scripts/smoke-full.sh
+++ b/scripts/smoke-full.sh
@@ -110,7 +110,7 @@ podman run -d \
   /sbin/init >/dev/null
 
 log_info "waiting for systemd inside container"
-for i in $(seq 1 30); do
+for i in $(seq 1 60); do
   if podman exec "$APP_NAME" systemctl is-system-running >/dev/null 2>&1 \
      || podman exec "$APP_NAME" systemctl is-system-running 2>/dev/null \
         | grep -qE '^(running|degraded|starting)$'; then
@@ -118,7 +118,11 @@ for i in $(seq 1 30); do
     break
   fi
   sleep 1
-  [[ $i == 30 ]] && die "systemd did not start in 30s"
+  if [[ $i == 60 ]]; then
+    # Surface the container console before dying — PID1 errors land there.
+    podman logs "$APP_NAME" 2>&1 | tail -40 >&2 || :
+    die "systemd did not start in 60s"
+  fi
 done
 
 exec_app() {


### PR DESCRIPTION
The first smoke-full run on main (27274677129) failed with 'systemd did not start in 30s' and the journal-dump step found nothing to inspect.

Two causes:
- The job ran podman as root (sudo). Root podman + systemd-in-container is broken on the ubuntu runners, and it was never the validated path — the end-to-end pass on 2026-06-09 was rootless. Drop sudo everywhere in the job (image build, smoke run, dump) so build and run share the same storage.
- smoke-full.sh's cleanup trap removes the pod on exit, so the on-failure journal dump always saw 'no such container'. Set KEEP_POD=1 in the job (the runner is ephemeral) and dump the container console from the script itself before dying.

Also raise the systemd boot wait from 30s to 60s for slower runners.