### PR TITLE
ci: rename smoke tests to test-install/test-integration taxonomy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ env:
 
 jobs:
   build:
-    name: Build & smoke-test all RPMs
+    name: Build & install-test all RPMs
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -94,11 +94,11 @@ jobs:
         working-directory: packages
         run: ls -lh dist/
 
-      - name: Smoke install inside Rocky 9
+      - name: Install test (Rocky 9)
         working-directory: packages
         env:
           CONTAINER_RUNNER: docker
-        run: ./scripts/smoke-install.sh
+        run: ./scripts/test-install.sh
 
       - name: Upload RPM artefacts
         if: success() || failure()
@@ -109,12 +109,12 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
-  # Full systemd + Postgres smoke. Reuses the RPM artifact from `build` — no rebuild.
-  # Runs on main pushes + manual dispatch only (PRs already get the file-level smoke
+  # Integration test: full systemd + Postgres. Reuses the RPM artifact from `build` — no rebuild.
+  # Runs on main pushes + manual dispatch only (PRs already get the file-level install test
   # above). Because publish-yum-repo triggers on this workflow's success, a failing
-  # full smoke also blocks the release.
-  smoke-full:
-    name: Full systemd + Postgres smoke
+  # failing integration test also blocks the release.
+  test-integration:
+    name: Integration test (systemd + Postgres)
     runs-on: ubuntu-latest
     timeout-minutes: 25
     needs: build
@@ -139,33 +139,33 @@ jobs:
           sudo apt-get install -y -qq podman uidmap
           podman --version
 
-      # smoke-full.sh boots a systemd container; the default centos:stream9 image is
+      # test-integration.sh boots a systemd container; the default centos:stream9 image is
       # minimal and has NO /sbin/init — build a systemd-capable image first.
       # Everything runs ROOTLESS: root podman + systemd-in-container breaks on the
       # ubuntu runners ("systemd did not start", run 27274677129), while the rootless
       # path is the one validated end-to-end. Same user for build + run = same storage.
       - name: Build systemd-capable app image
         run: |
-          podman build -t localhost/duynhlab-smoke-init:latest -f - . <<'EOF'
+          podman build -t localhost/duynhlab-test-init:latest -f - . <<'EOF'
           FROM quay.io/centos/centos:stream9
           RUN dnf -y install systemd && dnf clean all
           EOF
 
-      # KEEP_POD=1: smoke-full.sh's cleanup trap would otherwise remove the pod on
+      # KEEP_POD=1: test-integration.sh's cleanup trap would otherwise remove the pod on
       # failure, leaving the journal-dump step below with nothing to inspect. The
       # runner is ephemeral, so skipping cleanup is free.
-      - name: Full smoke (systemd + Postgres)
+      - name: Integration test
         working-directory: packages
         env:
-          APP_IMAGE: localhost/duynhlab-smoke-init:latest
+          APP_IMAGE: localhost/duynhlab-test-init:latest
           KEEP_POD: "1"
-        run: ./scripts/smoke-full.sh
+        run: ./scripts/test-integration.sh
 
       - name: Dump app journal on failure
         if: failure()
         run: |
           set +e
           podman ps -a
-          podman logs duynhlab-smoke-app    | tail -300 || true
-          podman logs duynhlab-smoke-db     | tail -100 || true
-          podman exec duynhlab-smoke-app journalctl -xe --no-pager | tail -500 || true
+          podman logs duynhlab-test-app    | tail -300 || true
+          podman logs duynhlab-test-db     | tail -100 || true
+          podman exec duynhlab-test-app journalctl -xe --no-pager | tail -500 || true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Guide for AI agents and contributors working on `duynhlab/packages`.
 - **Branching:** never commit on `main`; branch first (`feat/…`, `fix/…`, `docs/…`) and open a PR.
 - **Pre-PR checks:**
   - `bash -n` every script you touched (and `shellcheck` if installed).
-  - `make build` must produce a clean RPM; run `make smoke` (and `make smoke-full` when changing
+  - `make build` must produce a clean RPM; run `make test-install` (and `make test-integration` when changing
     runtime/migration/systemd behavior).
   - Keep changes surgical — every changed line should trace to the task (see `CLAUDE.md`).
 - **Scope:** service *code* lives in the `duynhlab/<svc>-service` repos, not here. This repo only
@@ -50,7 +50,7 @@ amd64.
 
 ```
 services.yaml                  Single source of truth: every service (repo/binary/port/grpc_port/db/deps)
-Makefile                       Local entrypoint (fetch-sources, build-local, stage, build, smoke, …)
+Makefile                       Local entrypoint (fetch-sources, build-local, stage, build, test-install, …)
 scripts/                       Build / render / ops scripts
 ├── lib/common.sh              Shared bash helpers (yq accessors: svc_field, svc_build_env, logging)
 ├── fetch-sources.sh           git clone/pull each service repo
@@ -59,7 +59,7 @@ scripts/                       Build / render / ops scripts
 ├── stage-all.sh               Assemble FHS payload → Source0 staging tarball
 ├── build-rpm.sh               rpmbuild specs/duynhlab.spec → dist/*.rpm (host/podman/docker)
 ├── publish-yum-repo.sh        createrepo_c → gh-pages YUM metadata
-└── smoke-install.sh / smoke-full.sh   install / full-systemd smoke tests
+└── test-install.sh / test-integration.sh   install / integration tests
 packages/
 ├── common/scripts/            duynhlab-ctl, duynhlab-db-setup, duynhlab-gen-env, duynhlab-gen-password
 └── rpm/
@@ -70,7 +70,7 @@ packages/
     └── lib/                   init-service.sh, password-generator.sh
 specs/duynhlab.spec            The mega-RPM SPEC (rpmbuild)
 docs/                          architecture.md, build.md, operations.md, install.md
-.github/workflows/             build.yml (build + smoke-full jobs), publish-yum-repo.yml
+.github/workflows/             build.yml (build + test-integration jobs), publish-yum-repo.yml
 build/  dist/                  Generated, gitignored — never hand-edit
 plan-spec.md                   Internal roadmap + decisions + backlog (gitignored)
 ```
@@ -114,14 +114,14 @@ make build-local-all            # build every service in services.yaml
 make render-systemd             # render units only
 make stage                      # assemble Source0 staging tarball
 make build                      # stage + rpmbuild -> dist/
-make smoke                      # file-level install check (Rocky 9 container)
-make smoke-full                 # full systemd boot + health (podman + Postgres sidecar)
+make test-install               # file-level install check (Rocky 9 container)
+make test-integration           # full systemd boot + health (podman + Postgres sidecar)
 make publish-repo               # stage gh-pages YUM tree
 make clean                      # rm build/ dist/
 ```
 
 Env knobs: `VERSION` (CalVer default), `DUYNHLAB_SRC_ROOT` (default `..`),
-`BUILD_RUNNER` (`host|podman|docker`), `APP_IMAGE` (smoke-full systemd image).
+`BUILD_RUNNER` (`host|podman|docker`), `APP_IMAGE` (test-integration systemd image).
 Lint = `bash -n` on every script (+ `shellcheck` when available). No Go toolchain build here — binaries
 come pre-built from the service repos.
 
@@ -155,21 +155,21 @@ come pre-built from the service repos.
 - **Ops CLI:** `duynhlab-ctl {list,start,stop,restart,status,enable,disable,logs,health,version,config,ports}`;
   `duynhlab-db-setup <svc> {bootstrap,migrate,status}` (`bootstrap` needs `SUPERUSER_DSN`).
 
-## Smoke testing
+## Testing
 
-- **`smoke-install.sh`** — installs the RPM in a `rockylinux:9` container, asserts the FHS layout and
+- **`test-install.sh`** — installs the RPM in a `rockylinux:9` container, asserts the FHS layout and
   that **no `migrations/` dir** and **no `duynhlab-db-migrate`** are shipped.
-- **`smoke-full.sh`** — podman pod with a Postgres 16 sidecar + a systemd app container; installs the
+- **`test-integration.sh`** — podman pod with a Postgres 16 sidecar + a systemd app container; installs the
   RPM, runs `bootstrap`+`migrate`+`status` per backend, `enable --now duynhlab-platform.target`, then
   `curl /health` for each service. Uses `ENV=production`.
   - **`APP_IMAGE` must contain `/sbin/init`.** The default `centos:stream9` is minimal (no systemd) —
     build one first:
     ```
-    podman build -t localhost/duynhlab-smoke-init - <<'D'
+    podman build -t localhost/duynhlab-test-init - <<'D'
     FROM quay.io/centos/centos:stream9
     RUN dnf -y install systemd && dnf clean all
     D
-    APP_IMAGE=localhost/duynhlab-smoke-init make smoke-full
+    APP_IMAGE=localhost/duynhlab-test-init make test-integration
     ```
 
 ## Gotchas and non-obvious rules

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # + CLI tools + nginx/valkey/postgresql config templates.
 
 .PHONY: help all fetch-sources build-local build-local-all render-systemd \
-        stage build smoke smoke-full publish-repo clean
+        stage build test-install test-integration publish-repo clean
 
 SERVICE          ?=
 VERSION          ?= $(shell date -u +%Y.%m.%d)
@@ -23,10 +23,10 @@ help:
 	@echo "  render-systemd             Render unit + target files (build/staging/systemd/)"
 	@echo "  stage                      Assemble the Source0 staging tarball"
 	@echo "  build                      Run rpmbuild (host or container) -> dist/"
-	@echo "  smoke                      Install dist/*.rpm in Rocky 9 + verify"
-	@echo "  smoke-full                 Full smoke: podman --systemd=always + Postgres sidecar"
+	@echo "  test-install               Install dist/*.rpm in Rocky 9 + verify"
+	@echo "  test-integration           Boot platform: podman --systemd=always + Postgres sidecar"
 	@echo "  publish-repo               Stage gh-pages YUM repo (build/gh-pages/)"
-	@echo "  all                        stage + build + smoke"
+	@echo "  all                        stage + build + test-install"
 	@echo "  clean                      Remove build/ and dist/"
 	@echo ""
 	@echo "Environment:"
@@ -56,16 +56,16 @@ stage:
 build: stage
 	@bash scripts/build-rpm.sh
 
-smoke:
-	@bash scripts/smoke-install.sh
+test-install:
+	@bash scripts/test-install.sh
 
-smoke-full:
-	@bash scripts/smoke-full.sh
+test-integration:
+	@bash scripts/test-integration.sh
 
 publish-repo:
 	@bash scripts/publish-yum-repo.sh
 
-all: stage build smoke
+all: stage build test-install
 
 clean:
 	@rm -rf dist/ build/

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ upgrade, remove): [`docs/install.md`](docs/install.md).
 make fetch-sources          # clone every service repo into ../
 make build-local-all        # compile binaries + frontend dist
 make build                  # stage Source0 tarball + rpmbuild -> dist/*.rpm
-make smoke                  # file-level install check in Rocky 9
+make test-install           # file-level install check in Rocky 9
 ```
 
 `BUILD_RUNNER=host|podman|docker` is auto-detected. Full pipeline, scripts, and
@@ -40,7 +40,7 @@ Makefile reference: [`docs/build.md`](docs/build.md).
 
 `build-rpms` ([`build.yml`](.github/workflows/build.yml)) validates every PR and
 push to `main` (docs-only changes are skipped): job `build` compiles everything,
-builds the mega-RPM and smoke-installs it; job `smoke-full` (main + manual) boots
+builds the mega-RPM and install-tests it; job `test-integration` (main + manual) boots
 the RPM under real systemd with a Postgres sidecar. Only when `build-rpms` is
 green on `main` does `publish-yum-repo`
 ([`publish-yum-repo.yml`](.github/workflows/publish-yum-repo.yml)) upload the RPM

--- a/docs/build.md
+++ b/docs/build.md
@@ -22,7 +22,7 @@ flowchart TD
   SRC0 --> BR[build-rpm.sh]
   SPEC[specs/duynhlab.spec] --> BR
   BR -->|rpmbuild| RPM[dist/duynhlab-VER-1.el9.x86_64.rpm]
-  RPM --> SM[smoke-install.sh / smoke-full.sh]
+  RPM --> SM[test-install.sh / test-integration.sh]
   RPM --> PUB[publish-yum-repo.sh]
   PUB -->|createrepo_c| GH[gh-pages YUM repo]
 ```
@@ -59,8 +59,8 @@ All scripts live in [`scripts/`](../scripts) and source
 >
 > Keep SRPMs only if you ever distribute via Fedora/EPEL or must ship source for
 > compliance — neither applies here.
-| `smoke-install.sh` | `dist/*.rpm` | — | File-level install check in Rocky 9 |
-| `smoke-full.sh` | `dist/*.rpm` | — | Full systemd boot + health check (podman + Postgres) |
+| `test-install.sh` | `dist/*.rpm` | — | File-level install check in Rocky 9 |
+| `test-integration.sh` | `dist/*.rpm` | — | Full systemd boot + health check (podman + Postgres) |
 
 ### Runner auto-detection
 
@@ -86,10 +86,10 @@ make build-local-all          # build every service in services.yaml
 make render-systemd           # render units only
 make stage                    # build Source0 staging tarball
 make build                    # stage + rpmbuild -> dist/
-make smoke                    # file-level install check
-make smoke-full               # full systemd smoke (podman + Postgres)
+make test-install             # file-level install check
+make test-integration         # full systemd boot + health (podman + Postgres)
 make publish-repo             # stage gh-pages YUM tree
-make all                      # stage + build + smoke
+make all                      # stage + build + test-install
 make clean                    # rm build/ dist/
 ```
 
@@ -115,10 +115,10 @@ make build
 ls -lh dist/                 # duynhlab-2026.06.01-1.el9.x86_64.rpm
 
 # 3. verify it installs cleanly
-make smoke
+make test-install
 
 # 4. (optional) full boot test with a real Postgres + systemd
-make smoke-full              # needs podman with cgroup v2
+make test-integration        # needs podman with cgroup v2
 
 # 5. (optional) stage a local YUM mirror
 REPO_OUT=/tmp/duynhlab-repo BASE_URL=http://localhost:8080 \
@@ -131,7 +131,7 @@ python3 -m http.server -d /tmp/duynhlab-repo 8080
 ```mermaid
 flowchart LR
   PR[PR / push to main<br/>except docs/** + *.md] --> B[build-rpms: build]
-  B -->|artifact, main only| S[build-rpms: smoke-full]
+  B -->|artifact, main only| S[build-rpms: test-integration]
   S -->|success on main| P[publish-yum-repo]
   P -->|gh release upload| REL[(GitHub Release<br/>RPM asset)]
   P -->|createrepo_c --location-prefix| GH[(gh-pages<br/>repodata only)]
@@ -140,7 +140,7 @@ flowchart LR
 
 | Workflow | File | Trigger | Does |
 |---|---|---|---|
-| **build-rpms** | [`build.yml`](../.github/workflows/build.yml) | PR + push to `main` (ignores `docs/**` + `**.md`), manual | Job `build`: fetch → build-local → render-systemd → **stage-all** → build-rpm → smoke-install → upload artefact. Job `smoke-full` (main + manual only, `needs: build`): download artifact → podman + systemd image → full systemd + Postgres smoke. A failing smoke-full blocks publish. |
+| **build-rpms** | [`build.yml`](../.github/workflows/build.yml) | PR + push to `main` (ignores `docs/**` + `**.md`), manual | Job `build`: fetch → build-local → render-systemd → **stage-all** → build-rpm → test-install → upload artefact. Job `test-integration` (main + manual only, `needs: build`): download artifact → podman + systemd image → full systemd + Postgres integration test. A failing test-integration blocks publish. |
 | **publish-yum-repo** | [`publish-yum-repo.yml`](../.github/workflows/publish-yum-repo.yml) | `workflow_run` after build-rpms on `main`, manual | rebuild RPM → **`gh release create v<VER>` + upload RPM** → `createrepo_c --location-prefix <release-url>` → force-push orphan `gh-pages` (repodata only) → `deploy-pages` |
 
 > **Critical ordering**: `stage-all.sh` must run before `build-rpm.sh` — the

--- a/docs/install.md
+++ b/docs/install.md
@@ -167,7 +167,7 @@ If you want to exercise the install path without GitHub Pages:
 
 ```bash
 cd packages
-make build-local-all build smoke
+make build-local-all build test-install
 # Stage a local YUM tree:
 REPO_OUT=/tmp/duynhlab-repo \
   BASE_URL=http://localhost:8080 \

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# smoke-install.sh — End-to-end install test for the mega-RPM in Rocky 9.
+# test-install.sh — End-to-end install test for the mega-RPM in Rocky 9.
 #
 # Verifies:
 #   - dnf localinstall succeeds and resolves all dependencies via EPEL + module
@@ -27,7 +27,7 @@ case $RUNNER in
   *)      VOL_OPTS="" ;;
 esac
 
-log_step "Running smoke test inside rockylinux:9 ($RUNNER)"
+log_step "Running install test inside rockylinux:9 ($RUNNER)"
 
 "$RUNNER" run --rm -i \
   -v "$REPO_ROOT:/work$VOL_OPTS" \
@@ -170,6 +170,6 @@ echo "::endgroup::"
 
 echo ""
 echo "================================================================"
-echo "  SMOKE TEST PASSED"
+echo "  INSTALL TEST PASSED"
 echo "================================================================"
 INNER

--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# scripts/smoke-full.sh — full-systemd smoke test (Phase 2.2).
+# scripts/test-integration.sh — full-systemd integration test.
 #
 # Spins up:
 #   * 1 podman pod (default) with a Postgres 16 sidecar
@@ -24,13 +24,13 @@
 #   APP_IMAGE           systemd-capable EL9 image (must contain /sbin/init).
 #                       The default centos:stream9 is MINIMAL and has NO systemd —
 #                       build one first, e.g.:
-#                         podman build -t localhost/duynhlab-smoke-init - <<'D'
+#                         podman build -t localhost/duynhlab-test-init - <<'D'
 #                         FROM quay.io/centos/centos:stream9
 #                         RUN dnf -y install systemd && dnf clean all
 #                         D
-#                       then run with APP_IMAGE=localhost/duynhlab-smoke-init
+#                       then run with APP_IMAGE=localhost/duynhlab-test-init
 #   POSTGRES_PASSWORD   randomly generated if unset
-#   POD_NAME            duynhlab-smoke
+#   POD_NAME            duynhlab-test
 #   KEEP_POD=1          don't tear down on exit (debug)
 set -euo pipefail
 
@@ -43,7 +43,7 @@ require_cmd podman
 POSTGRES_IMAGE="${POSTGRES_IMAGE:-docker.io/postgres:16-alpine}"
 APP_IMAGE="${APP_IMAGE:-quay.io/centos/centos:stream9}"
 POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-$(head -c 24 /dev/urandom | base64 | tr -d '+/=' | head -c 24)}"
-POD_NAME="${POD_NAME:-duynhlab-smoke}"
+POD_NAME="${POD_NAME:-duynhlab-test}"
 APP_NAME="$POD_NAME-app"
 DB_NAME_C="$POD_NAME-db"
 
@@ -146,7 +146,7 @@ log_step "rewrite env-global.properties to talk to sidecar postgres"
 exec_app '
   install -m 0644 /etc/duynhlab/env-global.properties /etc/duynhlab/env-global.properties.bak
   cat > /etc/duynhlab/env-global.properties <<EOF
-DUYNHLAB_VERSION=smoke
+DUYNHLAB_VERSION=integration-test
 LOG_LEVEL=info
 ENV=production
 DB_HOST=127.0.0.1
@@ -210,5 +210,5 @@ fi
 
 echo ""
 echo "================================================================"
-echo "  FULL SMOKE TEST PASSED — all backends healthy on real systemd"
+echo "  INTEGRATION TEST PASSED — all backends healthy on real systemd"
 echo "================================================================"


### PR DESCRIPTION
## Why

"smoke-full" was a contradiction in terms: a smoke test is by definition shallow and fast, while ours boots full systemd + Postgres, runs every migration and hits all 8 health endpoints — that is an **integration test**. The new names are self-explanatory for self-hosting customers and form a taxonomy that scales.

## Taxonomy

| New | Was | Nature |
|---|---|---|
| `test-install` | `smoke-install.sh` | Package acceptance: clean install, FHS layout, scriptlets, reinstall preserves env |
| `test-integration` | `smoke-full.sh` | Boot the whole platform: systemd + PG sidecar, bootstrap + migrate + `/health` ×8 |
| `test-upgrade` | *(future — backlog)* | Package N−1 → N: env preserved, services restart, schema advances |

**Future dimensions are matrix/env variables, NOT new script names**: `.deb` becomes a `PKG_FORMAT` dimension; infra versions (PostgreSQL 18, valkey, nginx) reuse the existing `POSTGRES_IMAGE`-style knobs on `test-integration` → CI jobs read as `test-integration (pg18)`.

## What

- `git mv` both scripts (97%/95% similarity preserved); internal headers, log banners, pod/image names (`duynhlab-test-*`).
- Makefile targets renamed, **no deprecated aliases** (clean break — `make smoke` now fails loudly).
- `build.yml`: job `smoke-full` → `test-integration`, step names updated. Workflow name `build-rpms` unchanged, so the `workflow_run` publish chain is untouched.
- Docs sweep: `docs/build.md`, `docs/install.md`, `README.md`, `AGENTS.md`. `grep -ri smoke` across tracked files → 0 hits.

## Verification

- `make test-install` local → INSTALL TEST PASSED.
- Dispatched this workflow from the branch: [run 27276184208](https://github.com/duynhlab/packages/actions/runs/27276184208) — **both jobs green** (`build` + the renamed `test-integration`).