### PR TITLE
ci: add dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+# Dependabot — this repo repacks pre-built binaries, so the only tracked
+# ecosystem is GitHub Actions (no go.mod / package.json / Dockerfile here;
+# container images used in workflows/scripts are inline and not trackable).
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    labels: ["dependencies", "github-actions"]
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    # Bundle all action bumps into one PR — each PR triggers a full ~12-min
+    # build, so one grouped PR beats eight individual ones.
+    groups:
+      gh-actions:
+        patterns: ["*"]


### PR DESCRIPTION
## What

Add `.github/dependabot.yml` tracking the **github-actions** ecosystem — the only one that applies here: this repo repacks pre-built binaries, so there is no `go.mod`/`package.json`/`Dockerfile` (the systemd test image is an inline heredoc Dependabot can't track).

- Daily schedule + `dependencies`/`github-actions` labels — same style as the `duynhlab/*-service` repos.
- **All action bumps grouped into one PR** (`groups`) — each PR triggers the full ~12-min build, so one grouped PR beats eight individual ones (8 actions currently in use).
- `commit-message: prefix ci, include scope` → `ci(deps): bump …`, consistent with Conventional Commits.