### PR TITLE
ci: fix release publish — force docker for createrepo, non-fatal cleanup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,6 +200,10 @@ jobs:
     env:
       TAG: ${{ needs.guard.outputs.tag }}
       VERSION: ${{ needs.guard.outputs.version }}
+      # Force docker for createrepo_c: the runner's preinstalled podman is
+      # rootless, and the in-container chown maps to a subuid the runner user
+      # can't clean up afterwards (run 27297…: rm Permission denied).
+      CREATEREPO_RUNNER: docker
     steps:
       - name: Checkout packages repo at tag
         uses: actions/checkout@v6

--- a/scripts/publish-yum-repo.sh
+++ b/scripts/publish-yum-repo.sh
@@ -144,7 +144,10 @@ if [[ -n "$RELEASE_BASE_URL" ]]; then
   rm -rf "$REPO_OUT/$ARCH_DIR/repodata"
   mkdir -p "$REPO_OUT/$ARCH_DIR"
   cp -rf "$CR_INPUT/repodata" "$REPO_OUT/$ARCH_DIR/repodata"
-  rm -rf "$CR_INPUT"
+  # Scratch cleanup must never fail the publish (rootless podman can leave
+  # subuid-owned files behind that the invoking user cannot remove).
+  rm -rf "$CR_INPUT" 2>/dev/null \
+    || log_warn "could not fully clean $CR_INPUT (container-owned files) — continuing"
 fi
 
 log_ok "repodata generated: $REPO_OUT/$ARCH_DIR/repodata/repomd.xml"


### PR DESCRIPTION
## What happened

First tag-driven release ([v2026.06.11 run](https://github.com/duynhlab/packages/actions)) — `guard` ✅, `build-test` ✅, Release created with notes + manifest ✅, but `publish` died **after** copying the repodata: `publish-yum-repo.sh` auto-picked the runner's preinstalled **rootless podman** for `createrepo_c` (the old workflow pinned `CREATEREPO_RUNNER: docker`; release.yml didn't). The in-container `chown` mapped scratch files to a subuid the runner user can't delete → `rm: Permission denied` → step failed → gh-pages push + Pages deploy skipped.

## Fix

- `release.yml`: `CREATEREPO_RUNNER: docker` on the publish job (restores parity with the old workflow — docker on the runner is rootful).
- `publish-yum-repo.sh`: scratch cleanup is now non-fatal (`|| log_warn`) — cleanup must never kill a publish.

## After merge

`gh workflow run release -f tag=v2026.06.11` — the idempotent re-publish path refreshes the existing release's assets and pushes the metadata (this also exercises verification item #6 of the redesign).