### PR TITLE
ci: grant deploy job pages/id-token permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -339,6 +339,11 @@ jobs:
     name: Deploy gh-pages tree to GitHub Pages
     needs: publish
     runs-on: ubuntu-latest
+    # Top-level permissions are contents:read — deploy-pages needs its own
+    # elevation (OIDC token), it does NOT inherit from the publish job.
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
Re-publish of v2026.06.11 got publish ✅ (createrepo fix worked, gh-pages pushed) but `deploy` failed: `Unable to get ACTIONS_ID_TOKEN_REQUEST_URL` — the workflow-level `permissions: contents: read` overrides job defaults, and only the publish job elevated itself. Give the deploy job its own `pages: write` + `id-token: write` (the old publish-yum-repo.yml had these at workflow level, which is why it worked there).