### PR TITLE
ci: extract shared build-test workflow; require yq; add release runbook

### DIFF
--- a/.github/workflows/_build-test.yml
+++ b/.github/workflows/_build-test.yml
@@ -1,0 +1,186 @@
+name: _build-test
+
+# Reusable build + test pipeline (workflow_call only) — the single source of
+# truth for "turn the 9 service repos into a tested mega-RPM". Called by:
+#   build.yml   (CI validation: version = CalVer date, artifact is CI-only)
+#   release.yml (releases:      version = tag, artifact gets published)
+# NOTE: caller `env:` does NOT propagate into a reusable workflow — everything
+# needed is defined here.
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "RPM version. Empty = CalVer date (CI dev builds)."
+        type: string
+        default: ""
+      run-integration:
+        description: "Run the full systemd + Postgres integration test job."
+        type: boolean
+        default: true
+      artifact-name:
+        description: "Name for the uploaded RPM (+ MANIFEST.txt) artifact."
+        type: string
+        required: true
+      services-ref:
+        description: "Git ref to check out for every service repo."
+        type: string
+        default: "main"
+      checkout-ref:
+        description: "Ref of THIS repo to build from (empty = triggering sha). Release re-publish passes the tag."
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+env:
+  DUYNHLAB_SRC_ROOT: ${{ github.workspace }}/src
+  CONTAINER_RUNNER: docker
+
+jobs:
+  build:
+    name: Build & install-test
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout packages repo
+        uses: actions/checkout@v6
+        with:
+          path: packages
+          ref: ${{ inputs.checkout-ref }}
+
+      - name: Set up Go (GOTOOLCHAIN=auto upgrades as needed per service)
+        uses: actions/setup-go@v6
+        with:
+          go-version: "stable"
+          check-latest: true
+
+      - name: Set up Node (for frontend)
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+
+      - name: Install host tools
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq gettext-base curl tar
+          # mikefarah yq v4 (build scripts parse services.yaml with it)
+          sudo curl -fsSL -o /usr/local/bin/yq \
+            https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+          yq --version
+
+      - name: Resolve version
+        run: |
+          v="${{ inputs.version }}"
+          [ -n "$v" ] || v="$(date -u +%Y.%m.%d)"
+          echo "VERSION=$v" >> "$GITHUB_ENV"
+          echo "Building version $v"
+
+      - name: Fetch every service source
+        working-directory: packages
+        run: ./scripts/fetch-sources.sh "${{ inputs.services-ref }}"
+
+      - name: Build all services (binaries + frontend dist)
+        working-directory: packages
+        run: |
+          set -euo pipefail
+          for svc in $(yq '.services[].name' services.yaml); do
+            echo "::group::build-local $svc"
+            ./scripts/build-local.sh "$svc" "$VERSION"
+            echo "::endgroup::"
+          done
+
+      - name: Render systemd units
+        working-directory: packages
+        run: ./scripts/render-systemd.sh
+
+      - name: Stage Source0 tarball (writes the composition manifest)
+        working-directory: packages
+        run: ./scripts/stage-all.sh
+
+      - name: Build mega-RPM (rpmbuild in container)
+        working-directory: packages
+        env:
+          BUILD_RUNNER: docker
+        run: ./scripts/build-rpm.sh
+
+      - name: Install test (Rocky 9)
+        working-directory: packages
+        run: ./scripts/test-install.sh
+
+      - name: Collect artifact (RPM + manifest)
+        working-directory: packages
+        run: |
+          set -euo pipefail
+          cp build/staging/opt/duynhlab/etc/manifest dist/MANIFEST.txt
+          ls -lh dist/
+
+      - name: Upload artifact
+        if: success() || failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: |
+            packages/dist/*.x86_64.rpm
+            packages/dist/MANIFEST.txt
+          if-no-files-found: error
+          retention-days: 14
+
+  # Full systemd + Postgres integration test — reuses the artifact, no rebuild.
+  test-integration:
+    name: Integration test (systemd + Postgres)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    needs: build
+    if: inputs.run-integration
+
+    steps:
+      - name: Checkout packages repo
+        uses: actions/checkout@v6
+        with:
+          path: packages
+          ref: ${{ inputs.checkout-ref }}
+
+      - name: Download RPM artifact from build job
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: packages/dist
+
+      - name: Install podman
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq podman uidmap
+          podman --version
+
+      # test-integration.sh boots a systemd container; the default centos:stream9
+      # image is minimal and has NO /sbin/init — build a systemd-capable image.
+      # Everything runs ROOTLESS (root podman + systemd-in-container breaks on
+      # the ubuntu runners).
+      - name: Build systemd-capable app image
+        run: |
+          podman build -t localhost/duynhlab-test-init:latest -f - . <<'EOF'
+          FROM quay.io/centos/centos:stream9
+          RUN dnf -y install systemd && dnf clean all
+          EOF
+
+      # KEEP_POD=1 so a failure leaves the containers for the journal dump below.
+      - name: Integration test
+        working-directory: packages
+        env:
+          APP_IMAGE: localhost/duynhlab-test-init:latest
+          KEEP_POD: "1"
+        run: ./scripts/test-integration.sh
+
+      - name: Dump app journal on failure
+        if: failure()
+        run: |
+          set +e
+          podman ps -a
+          podman logs duynhlab-test-app    | tail -300 || true
+          podman logs duynhlab-test-db     | tail -100 || true
+          podman exec duynhlab-test-app journalctl -xe --no-pager | tail -500 || true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,9 @@
 name: build-rpms
 
+# VALIDATION only — never publishes. Releases are cut by pushing a CalVer tag
+# (`make release`) → .github/workflows/release.yml. The actual pipeline lives
+# in the reusable _build-test.yml (shared with release.yml).
+
 on:
   push:
     branches: [main]
@@ -21,151 +25,13 @@ on:
 permissions:
   contents: read
 
-env:
-  DUYNHLAB_SRC_ROOT: ${{ github.workspace }}/src
-  CONTAINER_RUNNER: docker
-
 jobs:
-  build:
-    name: Build & install-test all RPMs
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-
-    steps:
-      - name: Checkout packages repo
-        uses: actions/checkout@v6
-        with:
-          path: packages
-
-      - name: Set up Go (GOTOOLCHAIN=auto upgrades as needed per service)
-        uses: actions/setup-go@v6
-        with:
-          go-version: "stable"
-          check-latest: true
-
-      - name: Set up Node (for frontend)
-        uses: actions/setup-node@v6
-        with:
-          node-version: "20"
-
-      - name: Install host tools
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq gettext-base curl tar
-          # mikefarah yq v4
-          sudo curl -fsSL -o /usr/local/bin/yq \
-            https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64
-          sudo chmod +x /usr/local/bin/yq
-          yq --version
-
-      - name: Fetch every service source
-        working-directory: packages
-        env:
-          DUYNHLAB_SRC_ROOT: ${{ env.DUYNHLAB_SRC_ROOT }}
-        run: ./scripts/fetch-sources.sh "${{ github.event.inputs.ref || 'main' }}"
-
-      - name: Build all services locally (binaries + frontend dist)
-        working-directory: packages
-        env:
-          DUYNHLAB_SRC_ROOT: ${{ env.DUYNHLAB_SRC_ROOT }}
-        run: |
-          set -euo pipefail
-          for svc in $(yq '.services[].name' services.yaml); do
-            echo "::group::build-local $svc"
-            ./scripts/build-local.sh "$svc"
-            echo "::endgroup::"
-          done
-
-      - name: Render systemd units
-        working-directory: packages
-        run: ./scripts/render-systemd.sh
-
-      - name: Stage Source0 tarball
-        working-directory: packages
-        run: ./scripts/stage-all.sh
-
-      - name: Build mega-RPM (rpmbuild in container)
-        working-directory: packages
-        env:
-          BUILD_RUNNER: docker
-        run: ./scripts/build-rpm.sh
-
-      - name: List artefacts
-        working-directory: packages
-        run: ls -lh dist/
-
-      - name: Install test (Rocky 9)
-        working-directory: packages
-        env:
-          CONTAINER_RUNNER: docker
-        run: ./scripts/test-install.sh
-
-      - name: Upload RPM artefacts
-        if: success() || failure()
-        uses: actions/upload-artifact@v7
-        with:
-          name: duynhlab-rpms
-          path: packages/dist/*.rpm
-          if-no-files-found: error
-          retention-days: 14
-
-  # Integration test: full systemd + Postgres. Reuses the RPM artifact from `build` — no rebuild.
-  # Runs on main pushes + manual dispatch only (PRs already get the file-level install test
-  # above). This workflow VALIDATES only — nothing here publishes. Releases are
-  # cut by pushing a CalVer tag (`make release`) → .github/workflows/release.yml.
-  test-integration:
-    name: Integration test (systemd + Postgres)
-    runs-on: ubuntu-latest
-    timeout-minutes: 25
-    needs: build
-    if: github.event_name != 'pull_request'
-
-    steps:
-      - name: Checkout packages repo
-        uses: actions/checkout@v6
-        with:
-          path: packages
-
-      - name: Download RPM artifact from build job
-        uses: actions/download-artifact@v8
-        with:
-          name: duynhlab-rpms
-          path: packages/dist
-
-      - name: Install podman
-        run: |
-          set -euo pipefail
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq podman uidmap
-          podman --version
-
-      # test-integration.sh boots a systemd container; the default centos:stream9 image is
-      # minimal and has NO /sbin/init — build a systemd-capable image first.
-      # Everything runs ROOTLESS: root podman + systemd-in-container breaks on the
-      # ubuntu runners ("systemd did not start", run 27274677129), while the rootless
-      # path is the one validated end-to-end. Same user for build + run = same storage.
-      - name: Build systemd-capable app image
-        run: |
-          podman build -t localhost/duynhlab-test-init:latest -f - . <<'EOF'
-          FROM quay.io/centos/centos:stream9
-          RUN dnf -y install systemd && dnf clean all
-          EOF
-
-      # KEEP_POD=1: test-integration.sh's cleanup trap would otherwise remove the pod on
-      # failure, leaving the journal-dump step below with nothing to inspect. The
-      # runner is ephemeral, so skipping cleanup is free.
-      - name: Integration test
-        working-directory: packages
-        env:
-          APP_IMAGE: localhost/duynhlab-test-init:latest
-          KEEP_POD: "1"
-        run: ./scripts/test-integration.sh
-
-      - name: Dump app journal on failure
-        if: failure()
-        run: |
-          set +e
-          podman ps -a
-          podman logs duynhlab-test-app    | tail -300 || true
-          podman logs duynhlab-test-db     | tail -100 || true
-          podman exec duynhlab-test-app journalctl -xe --no-pager | tail -500 || true
+  build-test:
+    name: build-test
+    uses: ./.github/workflows/_build-test.yml
+    with:
+      artifact-name: duynhlab-rpms
+      # PRs keep the fast path (file-level install test only); main pushes and
+      # manual dispatches also get the full systemd + Postgres integration test.
+      run-integration: ${{ github.event_name != 'pull_request' }}
+      services-ref: ${{ github.event.inputs.ref || 'main' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,111 +82,19 @@ jobs:
           echo "version=${tag#v}"  >> "$GITHUB_OUTPUT"
           echo "Releasing $tag (version ${tag#v}, commit $sha)"
 
+  # The shared pipeline (same one build.yml uses for CI) — version comes from
+  # the tag, so the RPM NEVR matches it, and the integration test runs on the
+  # exact artifact that publish ships. checkout-ref pins the repo to the tag
+  # (matters for workflow_dispatch re-publish, which runs from main).
   build-test:
-    name: Build + test (version = tag)
-    runs-on: ubuntu-latest
-    timeout-minutes: 45
+    name: build-test
     needs: guard
-    env:
-      VERSION: ${{ needs.guard.outputs.version }}
-    steps:
-      - name: Checkout packages repo at tag
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ needs.guard.outputs.tag }}
-          path: packages
-
-      - name: Set up Go (GOTOOLCHAIN=auto upgrades as needed per service)
-        uses: actions/setup-go@v6
-        with:
-          go-version: "stable"
-          check-latest: true
-
-      - name: Set up Node (for frontend)
-        uses: actions/setup-node@v6
-        with:
-          node-version: "20"
-
-      - name: Install host tools
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq gettext-base curl tar podman uidmap
-          sudo curl -fsSL -o /usr/local/bin/yq \
-            https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64
-          sudo chmod +x /usr/local/bin/yq
-          yq --version
-
-      - name: Fetch every service source
-        working-directory: packages
-        run: ./scripts/fetch-sources.sh main
-
-      - name: Build all services (version = ${{ needs.guard.outputs.version }})
-        working-directory: packages
-        run: |
-          set -euo pipefail
-          for svc in $(yq '.services[].name' services.yaml); do
-            echo "::group::build-local $svc"
-            ./scripts/build-local.sh "$svc" "$VERSION"
-            echo "::endgroup::"
-          done
-
-      - name: Render systemd units
-        working-directory: packages
-        run: ./scripts/render-systemd.sh
-
-      - name: Stage Source0 tarball (writes the composition manifest)
-        working-directory: packages
-        run: ./scripts/stage-all.sh
-
-      - name: Build mega-RPM
-        working-directory: packages
-        env:
-          BUILD_RUNNER: docker
-        run: ./scripts/build-rpm.sh
-
-      - name: Install test (Rocky 9)
-        working-directory: packages
-        run: ./scripts/test-install.sh
-
-      - name: Build systemd-capable app image
-        run: |
-          podman build -t localhost/duynhlab-test-init:latest -f - . <<'EOF'
-          FROM quay.io/centos/centos:stream9
-          RUN dnf -y install systemd && dnf clean all
-          EOF
-
-      - name: Integration test (systemd + Postgres)
-        working-directory: packages
-        env:
-          APP_IMAGE: localhost/duynhlab-test-init:latest
-          KEEP_POD: "1"
-        run: ./scripts/test-integration.sh
-
-      - name: Dump app journal on failure
-        if: failure()
-        run: |
-          set +e
-          podman ps -a
-          podman logs duynhlab-test-app    | tail -300 || true
-          podman logs duynhlab-test-db     | tail -100 || true
-          podman exec duynhlab-test-app journalctl -xe --no-pager | tail -500 || true
-
-      - name: Collect release artifact (RPM + manifest)
-        working-directory: packages
-        run: |
-          set -euo pipefail
-          cp build/staging/opt/duynhlab/etc/manifest dist/MANIFEST.txt
-          ls -lh dist/
-
-      - name: Upload release artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: duynhlab-release-${{ needs.guard.outputs.tag }}
-          path: |
-            packages/dist/*.x86_64.rpm
-            packages/dist/MANIFEST.txt
-          if-no-files-found: error
-          retention-days: 14
+    uses: ./.github/workflows/_build-test.yml
+    with:
+      version: ${{ needs.guard.outputs.version }}
+      checkout-ref: ${{ needs.guard.outputs.tag }}
+      run-integration: true
+      artifact-name: duynhlab-release-${{ needs.guard.outputs.tag }}
 
   publish:
     name: Publish (Release + YUM repo)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,8 +185,9 @@ come pre-built from the service repos.
 - **Every service defaults to HTTP `8080` and gRPC `9090` in code.** On a shared host they collide, so
   `PORT`/`GRPC_PORT` MUST be set per service from `services.yaml` (`port`, `grpc_port`).
 - **Env path is flat:** `/etc/duynhlab/<svc>.env`.
-- **`duynhlab-ctl` needs mikefarah `yq` at runtime** but the RPM does not yet `Requires: yq` — a known
-  gap; ensure `yq` is present on hosts that use `duynhlab-ctl`.
+- **`duynhlab-ctl`'s `yq` comes via `Requires: yq >= 4`** (EPEL ships mikefarah yq ≥4.47 on EL9 —
+  historically it was the unrelated python-yq, so re-verify if the floor ever changes). Don't bundle
+  a private copy; the ctl resolver prefers `/opt/duynhlab/lib/yq` only as an escape hatch (B6).
 - **Frontend `VITE_API_BASE_URL` is baked at build time** — changing the gateway origin requires a
   rebuild.
 - **Never co-locate two services in one database** — golang-migrate's unqualified `schema_migrations`

--- a/README.md
+++ b/README.md
@@ -57,4 +57,5 @@ releases**, so `dnf downgrade duynhlab` works. Details + rationale:
 | [`docs/architecture.md`](docs/architecture.md) | What ships in the package, FHS layout, systemd model, lifecycle |
 | [`docs/build.md`](docs/build.md) | Build pipeline, scripts, Makefile, CI workflows, publishing |
 | [`docs/operations.md`](docs/operations.md) | `duynhlab-ctl`, `duynhlab-db-setup`, systemd targets, day-2 ops |
+| [`docs/release.md`](docs/release.md) | Release runbook: cut, same-day hotfix, re-publish, rollback, audit |
 | [`AGENTS.md`](AGENTS.md) | Repository layout, conventions, contributor/agent guide |

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ pick the guide that matches your task.
 | [`install.md`](install.md) | Operators installing the RPM | Add the repo, install, bootstrap the database, start, upgrade, remove, troubleshooting |
 | [`architecture.md`](architecture.md) | Anyone | Why a mega-RPM, component map, services table, FHS layout, systemd model, install/upgrade/remove lifecycle diagrams, database model |
 | [`build.md`](build.md) | Contributors / release engineers | Build pipeline, scripts, runner auto-detection, Makefile targets, CI workflows, gh-pages publishing, versioning, adding a service |
+| [`release.md`](release.md) | Release engineers | Runbook: cut a release, same-day hotfix, re-publish a tag, rollback/downgrade, audit composition, troubleshooting per job |
 | [`operations.md`](operations.md) | Operators (day-2) | `duynhlab-ctl` and `duynhlab-db-setup` reference, bring-up flow, systemd targets, configuration files, upgrade, remove, troubleshooting |
 
 ## Conventions used in these docs

--- a/docs/build.md
+++ b/docs/build.md
@@ -153,6 +153,9 @@ make release        # computes next free tag (v2026.06.11 → v2026.06.11.1 …)
                     # creates an ANNOTATED tag, pushes it; release.yml does the rest
 ```
 
+Full operational runbook (same-day hotfix, re-publishing a tag, rollback,
+auditing a release's composition): [`release.md`](release.md).
+
 > **Critical ordering**: `stage-all.sh` must run before `build-rpm.sh` — the
 > spec's `Source0` is the staging tarball. Every build workflow includes that
 > step.

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,124 @@
+# Release Runbook
+
+Operational guide for cutting, re-publishing, rolling back, and auditing
+releases. Pipeline internals (scripts, workflows, hosting rationale):
+[`build.md`](build.md) § 5.
+
+## 1. Flow at a glance
+
+```
+merge to main ──► build-rpms (validate only — never publishes)
+
+make release  ──► annotated tag vYYYY.MM.DD[.N]
+                      │ push
+                      ▼
+              release.yml:  guard ─► build-test (VERSION = tag) ─► publish ─► deploy
+                                     └ the RPM that passes the tests is the
+                                       byte-identical RPM that gets published
+```
+
+Key invariants:
+
+- **Merging to `main` never publishes.** Only a tag does.
+- **Published == tested** — build, test, and publish happen in one run on one artifact.
+- The RPM's `Version:` always equals the tag (`v2026.06.11` → `duynhlab-2026.06.11-1.el9`).
+
+## 2. Cut a release
+
+```bash
+git checkout main && git pull
+make release
+```
+
+`make release` refuses to run unless you are on a **clean, up-to-date `main`**.
+It computes the next free CalVer tag for today, creates an **annotated** tag,
+and pushes it — `release.yml` does everything else. Follow along:
+
+```bash
+gh run watch "$(gh run list --workflow=release --limit 1 --json databaseId --jq '.[0].databaseId')"
+```
+
+When the run is green: the Release page has the RPM + `MANIFEST.txt`, and
+`https://duynhlab.github.io/packages` serves metadata indexing the last 3
+releases.
+
+## 3. Same-day hotfix
+
+Just run `make release` again — it sees `v2026.06.11` exists and cuts
+`v2026.06.11.1` (then `.2`, …). RPM version ordering handles the suffix
+correctly, so `dnf upgrade` moves customers forward as expected.
+
+## 4. Re-publish an existing tag
+
+When `publish` or `deploy` fails mid-run (Release exists but Pages metadata is
+stale, or vice versa), **do not** delete/re-push the tag. Re-publish it:
+
+```bash
+gh workflow run release -f tag=v2026.06.11
+```
+
+This is idempotent: it rebuilds + retests from the tag, refreshes the Release
+assets (`--clobber`) and notes, regenerates the repodata, and redeploys Pages.
+
+Real examples: the first ever cut needed this twice — PR #36 (createrepo ran
+under rootless podman and the scratch cleanup failed) and PR #37 (the deploy
+job was missing `id-token: write`). Both times the fix landed on `main` and a
+re-publish completed the release without touching the tag.
+
+> A plain tag push onto an existing release is **rejected by `guard`** — silent
+> overwrites are exactly what this design removes.
+
+## 5. Rollback / downgrade
+
+The YUM metadata indexes the **last 3 releases**:
+
+```bash
+dnf list duynhlab --showduplicates       # what's available
+sudo dnf downgrade -y duynhlab           # one step back
+sudo dnf install -y duynhlab-2026.06.09  # pin an exact version
+```
+
+Older than that: download from the
+[Releases page](https://github.com/duynhlab/packages/releases) and
+`dnf install ./duynhlab-<ver>-1.el9.x86_64.rpm`.
+
+> ⚠️ Migrations are **forward-only** — downgrading the package does not
+> downgrade the schema. Only downgrade across versions with the same
+> `SCHEMA_VERSION` (check the release notes / manifest), or restore the DB from
+> a pre-upgrade backup. See [`install.md`](install.md) § Downgrade.
+
+## 6. Audit a release
+
+Every release records its exact composition — the commit of each of the 9
+service repos it was built from — in three places that must agree:
+
+| Where | What |
+|---|---|
+| Release notes | "Composition" table |
+| `MANIFEST.txt` release asset | machine-readable copy |
+| `/opt/duynhlab/etc/manifest` on an installed host | the same file, shipped in the RPM |
+
+To verify what a customer is actually running:
+
+```bash
+cat /opt/duynhlab/etc/manifest          # on the host
+gh release download v2026.06.11 --pattern MANIFEST.txt -O - | diff - /opt/duynhlab/etc/manifest
+```
+
+## 7. Troubleshooting by job
+
+| Job | Symptom | Cause / action |
+|---|---|---|
+| `guard` | "not vYYYY.MM.DD[.N]" | Tag was hand-crafted with the wrong format — use `make release` |
+| `guard` | "not an ancestor of main" | Tag points at unmerged code — merge first, re-tag |
+| `guard` | "Release already exists" | You re-pushed an existing tag — use the re-publish dispatch (§4) |
+| `build-test` | integration test red | Read the "Dump app journal on failure" step — it has `podman logs` + `journalctl` from inside the systemd container |
+| `publish` / `deploy` | failed after Release was created | Fix the cause on `main`, then re-publish the tag (§4) — never delete the tag |
+
+## 8. Where things live
+
+| Artifact | Location |
+|---|---|
+| RPM + `MANIFEST.txt` | GitHub Release asset (`releases/download/v<tag>/…`) |
+| YUM metadata (`repodata/`, `duynhlab.repo`) | `gh-pages` branch → GitHub Pages (KB-sized, orphan, force-pushed per publish) |
+| CI artifacts (unreleased builds) | Actions artifacts, 14-day retention — never customer-visible |

--- a/packages/common/scripts/duynhlab-ctl
+++ b/packages/common/scripts/duynhlab-ctl
@@ -29,11 +29,19 @@ fi
 
 die() { echo "$PROG: $*" >&2; exit 1; }
 
-require_yq() { command -v yq >/dev/null 2>&1 || die "yq required (install: go install github.com/mikefarah/yq/v4@latest)"; }
+# mikefarah yq — normally on PATH via the RPM's `Requires: yq` (EPEL ≥4.47).
+# A copy at $OPT_BASE/lib/yq takes precedence if present (escape hatch), and
+# YQ=… overrides everything.
+YQ=${YQ:-}
+if [[ -z "$YQ" ]]; then
+  if [[ -x "$OPT_BASE/lib/yq" ]]; then YQ="$OPT_BASE/lib/yq"; else YQ=yq; fi
+fi
 
-list_services() { require_yq; yq '.services[].name' "$SERVICES_YAML"; }
-svc_port() { yq ".services[] | select(.name==\"$1\") | .port" "$SERVICES_YAML"; }
-svc_type() { yq ".services[] | select(.name==\"$1\") | .type" "$SERVICES_YAML"; }
+require_yq() { command -v "$YQ" >/dev/null 2>&1 || die "yq not found — install mikefarah yq (EPEL: dnf install yq)"; }
+
+list_services() { require_yq; "$YQ" '.services[].name' "$SERVICES_YAML"; }
+svc_port() { "$YQ" ".services[] | select(.name==\"$1\") | .port" "$SERVICES_YAML"; }
+svc_type() { "$YQ" ".services[] | select(.name==\"$1\") | .type" "$SERVICES_YAML"; }
 
 resolve_targets() {
   if [[ "$1" == "all" ]]; then list_services; else echo "$1"; fi
@@ -105,7 +113,7 @@ cmd_config() {
 cmd_ports() {
   require_yq
   local filter=${1:-}
-  yq -r ".services[] | [.name, .port, .type] | @tsv" "$SERVICES_YAML" \
+  "$YQ" -r ".services[] | [.name, .port, .type] | @tsv" "$SERVICES_YAML" \
     | { [[ -n "$filter" ]] && grep -i "$filter" || cat; } \
     | column -t
 }

--- a/packages/common/scripts/duynhlab-ctl.bash-completion
+++ b/packages/common/scripts/duynhlab-ctl.bash-completion
@@ -9,9 +9,10 @@ _duynhlab_ctl() {
     return
   fi
 
-  local svcs=""
-  if command -v yq >/dev/null 2>&1 && [[ -f /etc/duynhlab/services.yaml ]]; then
-    svcs=$(yq '.services[].name' /etc/duynhlab/services.yaml 2>/dev/null)
+  local svcs="" yq_bin=yq
+  [[ -x /opt/duynhlab/lib/yq ]] && yq_bin=/opt/duynhlab/lib/yq
+  if command -v "$yq_bin" >/dev/null 2>&1 && [[ -f /etc/duynhlab/services.yaml ]]; then
+    svcs=$("$yq_bin" '.services[].name' /etc/duynhlab/services.yaml 2>/dev/null)
   fi
 
   case "${words[1]}" in

--- a/scripts/stage-all.sh
+++ b/scripts/stage-all.sh
@@ -92,6 +92,8 @@ install -m 0644 "$REPO_ROOT/packages/common/scripts/duynhlab-ctl.bash-completion
 install -m 0755 "$REPO_ROOT/packages/rpm/lib/init-service.sh"               "$OPT/lib/"
 install -m 0755 "$REPO_ROOT/packages/rpm/lib/password-generator.sh"         "$OPT/lib/"
 log_ok "staged CLI + lib"
+# NOTE: duynhlab-ctl's yq comes via `Requires: yq` in the spec (EPEL ships
+# mikefarah yq ≥4.47 on EL9) — nothing to bundle here.
 
 # ── 4. Config templates ───────────────────────────────────────────────────────
 cp -a "$REPO_ROOT/packages/rpm/nginx/."      "$OPT/nginx/"

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -39,7 +39,9 @@ echo "::group::Repo + dependency setup"
 dnf -y install epel-release >/dev/null
 dnf -y module enable postgresql:16 >/dev/null
 # Valkey lives in EPEL on EL9; nginx in AppStream; redis in EPEL.
-dnf -y install yq postgresql nginx valkey shadow-utils which file >/dev/null
+# Deliberately NO yq here: customer hosts won't have it — duynhlab-ctl must
+# work with the copy bundled in the RPM (/opt/duynhlab/lib/yq).
+dnf -y install postgresql nginx valkey shadow-utils which file >/dev/null
 echo "::endgroup::"
 
 echo "::group::dnf localinstall mega-RPM"
@@ -89,7 +91,15 @@ done
 ! which duynhlab-db-migrate 2>/dev/null || { echo "UNEXPECTED duynhlab-db-migrate present"; exit 1; }
 duynhlab-gen-password 16 || true
 test -f /etc/duynhlab/services.yaml || { echo "services.yaml not dropped"; exit 1; }
-yq '.services[].name' /etc/duynhlab/services.yaml | tr '\n' ' '; echo
+echo "::endgroup::"
+
+echo "::group::duynhlab-ctl works out-of-box (yq pulled as RPM dependency)"
+# We never install yq by hand in this test — `Requires: yq` must have made dnf
+# pull it (mikefarah yq from EPEL). This reproduces a clean customer host.
+command -v yq >/dev/null 2>&1 || { echo "MISSING yq — Requires: yq not resolved"; exit 1; }
+yq --version | grep -q mikefarah || { echo "WRONG yq (expected mikefarah): $(yq --version)"; exit 1; }
+duynhlab-ctl list
+duynhlab-ctl ports
 echo "::endgroup::"
 
 echo "::group::systemd units"

--- a/specs/duynhlab.spec
+++ b/specs/duynhlab.spec
@@ -39,6 +39,9 @@ Requires:       coreutils
 Requires:       nginx >= 1.20
 Requires:       postgresql >= 14
 Requires:       (valkey >= 7.2 or redis >= 6)
+# mikefarah yq (EPEL ≥4.47 on EL9) — duynhlab-ctl parses services.yaml with it.
+# EPEL is already a documented prerequisite (valkey lives there too).
+Requires:       yq >= 4
 Requires(pre):  shadow-utils
 Requires(pre):  /usr/bin/getent
 %{?systemd_requires}


### PR DESCRIPTION
## What

Three related hygiene changes (B15 + B6 + release docs):

### 1. B15 — single source of truth for the pipeline
`build.yml` and `release.yml` duplicated ~150 lines (setup → fetch → build ×9 → stage → rpmbuild → test-install → integration). Extracted into **`_build-test.yml`** (workflow_call; inputs `version` / `run-integration` / `artifact-name` / `services-ref` / `checkout-ref`). `build.yml` 171 → **37** lines, `release.yml` 353 → **261**. `checkout-ref` pins the repo to the tag so a re-publish dispatch builds from the tag, not main.

### 2. B6 — `duynhlab-ctl` works out-of-box: `Requires: yq >= 4`
The original B6 analysis assumed EPEL's `yq` was the unrelated python-yq — **stale info**: EPEL EL9 now ships real mikefarah yq (≥ 4.47, verified `dnf info yq`), and EPEL is already a documented prerequisite (valkey). So the plain RPM dependency is the right fix: EPEL owns CVE updates, RPM stays 70 MB.

Also fixes the **test that masked this gap**: `test-install.sh` used to `dnf install yq` by hand, so the missing dependency never surfaced. It now installs nothing manually and asserts dnf pulled mikefarah yq via the dependency + `duynhlab-ctl list/ports` render on a clean host. `ctl` gains a `YQ` resolver (`/opt/duynhlab/lib/yq` escape hatch → PATH).

### 3. `docs/release.md` — operational runbook
Cut a release, same-day hotfix (`.N`), re-publish an existing tag (the two real incidents #36/#37 as worked examples), rollback/downgrade, auditing composition via the manifest, troubleshooting per job. Linked from README, docs index, and build.md §5.

## Verification

- Local: `rpm -qp --requires` shows `yq >= 4`; `test-install` PASSED with dnf resolving yq from EPEL and ctl rendering all 9 services.
- CI: dispatched `build-rpms` from this branch — **both reusable jobs green** (`build-test / Build & install-test`, `build-test / Integration test`).