### PR TITLE
docs: fix false schema-gate claim, broken landing-page command, drift

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,8 @@ packages/
     └── lib/                   init-service.sh, password-generator.sh
 specs/duynhlab.spec            The mega-RPM SPEC (rpmbuild)
 docs/                          architecture.md, build.md, operations.md, install.md
-.github/workflows/             build.yml (validate: build + test-integration), release.yml (tag-driven publish)
+.github/workflows/             _build-test.yml (reusable pipeline), build.yml (validate — calls it),
+                               release.yml (tag-driven publish — calls it too)
 build/  dist/                  Generated, gitignored — never hand-edit
 plan-spec.md                   Internal roadmap + decisions + backlog (gitignored)
 ```
@@ -100,7 +101,9 @@ Three stages, all driven by `services.yaml`:
    + `build-info.env` (carries `SCHEMA_VERSION` = highest embedded migration, audit-only).
 2. **`stage-all.sh`** — extract every backend tarball + frontend dist into
    `build/staging/opt/duynhlab/`, write `BINARY_VERSION`/`SCHEMA_VERSION`, copy CLI tools + config
-   templates, run `render-systemd.sh`, then tar everything as the Source0 staging tarball.
+   templates, generate the **composition manifest** (`etc/manifest` — the 9 service SHAs, used by
+   release notes and shipped in the RPM), run `render-systemd.sh`, then tar everything as the
+   Source0 staging tarball.
 3. **`build-rpm.sh`** — `rpmbuild -ba specs/duynhlab.spec` (host, else podman/rockylinux:9, else
    docker) → `dist/duynhlab-<VERSION>-1.el9.x86_64.rpm`.
 
@@ -117,6 +120,7 @@ make build                      # stage + rpmbuild -> dist/
 make test-install               # file-level install check (Rocky 9 container)
 make test-integration           # full systemd boot + health (podman + Postgres sidecar)
 make publish-repo               # stage gh-pages YUM tree
+make release                    # cut a release: next CalVer tag -> push -> release.yml publishes
 make clean                      # rm build/ dist/
 ```
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,10 @@ Makefile reference: [`docs/build.md`](docs/build.md).
 ## CI in one paragraph
 
 `build-rpms` ([`build.yml`](.github/workflows/build.yml)) **validates** every PR
-and push to `main` (docs-only changes skipped) — build, install test, full
-systemd + Postgres integration test — but never publishes. A **release is cut by
+and push to `main` (docs-only changes skipped) — build + install test on every
+run, plus the full systemd + Postgres integration test on `main` pushes and
+manual dispatches — but never publishes. Both it and `release.yml` share one
+pipeline: [`_build-test.yml`](.github/workflows/_build-test.yml). A **release is cut by
 pushing a CalVer tag** (`make release` → `v2026.06.11`, second cut of the day
 `v2026.06.11.1`): [`release.yml`](.github/workflows/release.yml) builds the RPM
 with the tag as its version, runs the same tests on that exact RPM, then uploads

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -55,7 +55,7 @@ flowchart TB
 | cart | 8004 | `duynhlab_cart` | — |
 | order | 8005 | `duynhlab_order` | — |
 | review | 8006 | `duynhlab_review` | — |
-| notification | 8007 | `duynhlab_notification` | `valkey`/`redis` |
+| notification | 8007 | `duynhlab_notification` | — |
 | shipping | 8008 | `duynhlab_shipping` | — |
 | frontend | — | — | static, served by nginx |
 
@@ -76,7 +76,9 @@ flowchart TB
 ├── logrotate/ secret-tpl/
 └── etc/
     ├── services.yaml               Runtime copy read by CLI tools
-    └── env-global.properties       Shared env (DB host, etc.)
+    ├── env-global.properties       Shared env (DB host, etc.)
+    └── manifest                    Composition: the 9 service commits this
+                                    build was made from (audit / release notes)
 
 /etc/duynhlab/                      Mutable state (NOT overwritten on upgrade)
 ├── env-global.properties           Global overrides

--- a/docs/build.md
+++ b/docs/build.md
@@ -38,7 +38,7 @@ All scripts live in [`scripts/`](../scripts) and source
 | `fetch-sources.sh [ref]` | `services.yaml` | `$DUYNHLAB_SRC_ROOT/<svc>` | `git clone`/`pull` every service repo at `ref` (default `main`) |
 | `build-local.sh <svc> [ver]` | sibling checkout | `build/<svc>/raw/*.tar.gz` + `.sha256` | Compile one service (`CGO_ENABLED=0 GOOS=linux GOARCH=amd64`) or `npm build` for frontend; tar binary + migrations |
 | `render-systemd.sh [outdir]` | `services.yaml` + tmpl | `build/systemd/` | Render per-service `.service` + `duynhlab-platform.target` |
-| `stage-all.sh` | `build/*/raw/` + units | `build/sources/duynhlab-<ver>-staging.tar.gz` | Assemble the FHS payload tree → Source0 tarball |
+| `stage-all.sh` | `build/*/raw/` + units | `build/sources/duynhlab-<ver>-staging.tar.gz` | Assemble the FHS payload tree + generate the composition manifest (`etc/manifest`) → Source0 tarball |
 | `build-rpm.sh` | Source0 + spec | `dist/*.rpm` | `rpmbuild -ba specs/duynhlab.spec` |
 | `publish-yum-repo.sh` | `dist/*.x86_64.rpm` | `build/gh-pages/` | `createrepo_c` + landing page + `duynhlab.repo` |
 
@@ -89,6 +89,7 @@ make build                    # stage + rpmbuild -> dist/
 make test-install             # file-level install check
 make test-integration         # full systemd boot + health (podman + Postgres)
 make publish-repo             # stage gh-pages YUM tree
+make release                  # cut a release: next CalVer tag -> push -> release.yml
 make all                      # stage + build + test-install
 make clean                    # rm build/ dist/
 ```

--- a/docs/install.md
+++ b/docs/install.md
@@ -131,9 +131,10 @@ sudo systemctl restart duynhlab-platform.target
 Upgrades:
 
 - **Preserve** `/etc/duynhlab/*.env` and the database.
-- **Refuse to start** a service whose binary expects a higher
-  `SCHEMA_VERSION` than what is applied in the DB — run
-  `duynhlab-db-setup migrate` first.
+- **Do not auto-migrate.** Always run `duynhlab-db-setup migrate <svc>` after an
+  upgrade — a new binary may query tables/columns its embedded migrations have
+  not created yet, failing at runtime with SQL errors. (`SCHEMA_VERSION` under
+  `/opt/duynhlab/<svc>/` is audit metadata only — nothing blocks startup.)
 
 ### Downgrade / pin a version
 
@@ -178,7 +179,7 @@ sudo -u postgres psql -c "DROP DATABASE duynhlab_auth;" ...
 | Symptom | Likely cause | Fix |
 |---|---|---|
 | `dnf install` fails: `Curl error (60): SSL certificate problem` | Mirror reach is restricted | `dnf install --setopt=sslverify=false` once, then fix CA |
-| `systemctl start duynhlab-auth` fails: "schema version mismatch" | Forgot `duynhlab-db-setup migrate auth` after upgrade | Run it, then restart |
+| Service starts but logs SQL errors (missing table/column) after an upgrade | Forgot `duynhlab-db-setup migrate auth` | Run it, then `systemctl restart duynhlab-auth` |
 | `nginx -t` fails after install | Existing `nginx.conf` already defines `server { listen 80; }` | Edit `/etc/nginx/nginx.conf` to remove the default `server` block; ours lives in `conf.d/duynhlab.conf` |
 | `duynhlab-ctl status` shows `inactive (dead)` | DB unreachable or password wrong | `grep DB_PASSWORD /etc/duynhlab/<svc>.env`, verify via `psql` |
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -8,7 +8,8 @@ databases, and troubleshooting. All commands assume `root` (or `sudo`).
 ## 1. `duynhlab-ctl` — service control
 
 A thin, safe wrapper around `systemctl`/`journalctl` that knows the service
-list from `/etc/duynhlab/services.yaml`.
+list from `/etc/duynhlab/services.yaml` (parsed with mikefarah `yq`, which the
+RPM pulls automatically via `Requires: yq` — no manual install needed).
 
 ```
 duynhlab-ctl <command> [svc|all] [args]
@@ -120,9 +121,10 @@ done
 systemctl restart duynhlab-platform.target
 ```
 
-Upgrades preserve `/etc/duynhlab/*.env` and the database. A backend refuses to
-start if its binary expects a newer schema than is applied — run `migrate`
-first.
+Upgrades preserve `/etc/duynhlab/*.env` and the database. Nothing blocks a
+backend from starting against an outdated schema (`SCHEMA_VERSION` is audit
+metadata only) — a binary running ahead of its migrations fails at runtime
+with SQL errors, so always run `migrate` before restarting.
 
 ## 7. Remove
 
@@ -145,7 +147,7 @@ sudo -u postgres psql -c "DROP DATABASE duynhlab_auth;"   # … per service
 | Symptom | Likely cause | Fix |
 |---|---|---|
 | `duynhlab-ctl status` shows `inactive (dead)` | DB unreachable / wrong password | `duynhlab-ctl config <svc>`, verify with `psql` |
-| Service fails: "schema version mismatch" | Forgot `migrate` after upgrade | `duynhlab-db-setup migrate <svc>`, restart |
+| Service logs SQL errors (missing table/column) after upgrade | Forgot `migrate` | `duynhlab-db-setup migrate <svc>`, restart |
 | `nginx -t` fails after install | Existing `server { listen 80; }` in `nginx.conf` | Remove the default server block; ours is in `conf.d/duynhlab.conf` |
 | `health` reports connection refused | Service not started or wrong port | `duynhlab-ctl start <svc>`; check `duynhlab-ctl ports` |
 | `db-setup bootstrap` errors `SUPERUSER_DSN` | Env var not exported | `export SUPERUSER_DSN=postgresql://postgres:…` |

--- a/scripts/publish-yum-repo.sh
+++ b/scripts/publish-yum-repo.sh
@@ -187,9 +187,11 @@ Hosted on GitHub Pages, backed by the
 sudo dnf install -y duynhlab</pre>
 
 <h2>Bootstrap</h2>
-<pre>SUPERUSER_DSN="postgresql://postgres:secret@localhost:5432/postgres" \\
-  sudo -E duynhlab-db-setup bootstrap
-sudo duynhlab-db-setup migrate
+<pre>for svc in auth user product cart order review notification shipping; do
+  SUPERUSER_DSN="postgresql://postgres:secret@localhost:5432/postgres" \\
+    sudo -E duynhlab-db-setup bootstrap "\$svc"
+  sudo duynhlab-db-setup migrate "\$svc"
+done
 sudo systemctl enable --now duynhlab-platform.target</pre>
 
 <h2>Browse</h2>


### PR DESCRIPTION
## Why

Three-agent documentation audit, every claim cross-checked against the actual code.

## Findings fixed

| Severity | Finding |
|---|---|
| 🔴 **False claim** (4 places) | install.md + operations.md said a backend **"refuses to start"** on SCHEMA_VERSION mismatch. **No such gate exists** — not in the systemd unit, not in ctl, not in the service binaries (verified `auth-service/cmd/main.go`). `SCHEMA_VERSION` is audit-only. Reworded to reality: a binary ahead of its migrations fails at runtime with SQL errors → always `migrate` after upgrade. The invented "schema version mismatch" troubleshooting rows fixed too. |
| 🟠 **Broken command on the live landing page** | `publish-yum-repo.sh` generates `index.html` with `duynhlab-db-setup bootstrap` / `migrate` **missing the required `<svc>` arg** — copy-paste errors immediately. Now a per-service loop (matches install.md + the spec's `%post` hint). Takes effect on the next release. |
| 🟡 Drift | architecture.md: notification still showed `valkey/redis` `After=` (PostgreSQL-only since #26); FHS tree missing `etc/manifest`. AGENTS.md: `_build-test.yml` absent from layout, manifest absent from pipeline step, `make release` absent from targets. docs/build.md: same two gaps. README: CI paragraph implied integration test runs on PRs (main + manual only) and didn't mention the shared reusable. operations.md: note that `yq` arrives via `Requires:`. |

Verified-accurate (no change needed): release.md commands/jobs, install.md prerequisites + downgrade section, docs index, migration/manifest/FHS claims elsewhere.

> Note: this touches `scripts/publish-yum-repo.sh` (not docs-only), so the PR build will run.