### PR TITLE
docs: number the docs as a reading order; add 006-add-service onboarding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,7 @@ packages/
     ├── nginx/ valkey/ postgresql/ logrotate/   config templates
     └── lib/                   init-service.sh, password-generator.sh
 specs/duynhlab.spec            The mega-RPM SPEC (rpmbuild)
-docs/                          architecture.md, build.md, operations.md, install.md
+docs/                          numbered reading order: 001-architecture … 006-add-service (see docs/README.md)
 .github/workflows/             _build-test.yml (reusable pipeline), build.yml (validate — calls it),
                                release.yml (tag-driven publish — calls it too)
 build/  dist/                  Generated, gitignored — never hand-edit

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ sudo dnf install -y duynhlab
 
 Then bootstrap the per-service databases and start the platform — full steps
 (prerequisites, per-service `duynhlab-db-setup bootstrap`/`migrate`, verify,
-upgrade, remove): [`docs/install.md`](docs/install.md).
+upgrade, remove): [`docs/002-install.md`](docs/002-install.md).
 
 ### Build locally (maintainer)
 
@@ -34,7 +34,7 @@ make test-install           # file-level install check in Rocky 9
 ```
 
 `BUILD_RUNNER=host|podman|docker` is auto-detected. Full pipeline, scripts, and
-Makefile reference: [`docs/build.md`](docs/build.md).
+Makefile reference: [`docs/004-build.md`](docs/004-build.md).
 
 ## CI in one paragraph
 
@@ -49,15 +49,16 @@ with the tag as its version, runs the same tests on that exact RPM, then uploads
 it to a GitHub Release (notes auto-generated + a manifest of the 9 service
 commits) and refreshes the YUM metadata on Pages — indexing the **last 3
 releases**, so `dnf downgrade duynhlab` works. Details + rationale:
-[`docs/build.md`](docs/build.md) § CI workflows.
+[`docs/004-build.md`](docs/004-build.md) § CI workflows.
 
 ## Documentation
 
 | Doc | Contents |
 |---|---|
-| [`docs/install.md`](docs/install.md) | End-user install, bootstrap, upgrade, remove, troubleshooting |
-| [`docs/architecture.md`](docs/architecture.md) | What ships in the package, FHS layout, systemd model, lifecycle |
-| [`docs/build.md`](docs/build.md) | Build pipeline, scripts, Makefile, CI workflows, publishing |
-| [`docs/operations.md`](docs/operations.md) | `duynhlab-ctl`, `duynhlab-db-setup`, systemd targets, day-2 ops |
-| [`docs/release.md`](docs/release.md) | Release runbook: cut, same-day hotfix, re-publish, rollback, audit |
+| [`docs/001-architecture.md`](docs/001-architecture.md) | What ships in the package, FHS layout, systemd model, lifecycle |
+| [`docs/002-install.md`](docs/002-install.md) | End-user install, bootstrap, upgrade, downgrade, remove, troubleshooting |
+| [`docs/003-operations.md`](docs/003-operations.md) | `duynhlab-ctl`, `duynhlab-db-setup`, systemd targets, day-2 ops |
+| [`docs/004-build.md`](docs/004-build.md) | Build pipeline, scripts, Makefile, CI workflows, publishing |
+| [`docs/005-release.md`](docs/005-release.md) | Release runbook: cut, same-day hotfix, re-publish, rollback, audit |
+| [`docs/006-add-service.md`](docs/006-add-service.md) | Onboarding a new service: prerequisites, registry entry, touch-point checklist |
 | [`AGENTS.md`](AGENTS.md) | Repository layout, conventions, contributor/agent guide |

--- a/docs/001-architecture.md
+++ b/docs/001-architecture.md
@@ -199,4 +199,4 @@ flowchart LR
   role against the direct DB host. Forward-only; no separate migrate tool, no
   loose SQL.
 
-See [operations.md](operations.md) for the commands.
+See [operations.md](003-operations.md) for the commands.

--- a/docs/002-install.md
+++ b/docs/002-install.md
@@ -202,5 +202,5 @@ sudo dnf install duynhlab
 ```
 
 See also: [`docs/README.md`](README.md) for the full documentation index —
-in particular [`build.md`](build.md) for the publish flow and
-[`operations.md`](operations.md) for day-2 operations.
+in particular [`004-build.md`](004-build.md) for the publish flow and
+[`003-operations.md`](003-operations.md) for day-2 operations.

--- a/docs/003-operations.md
+++ b/docs/003-operations.md
@@ -153,5 +153,5 @@ sudo -u postgres psql -c "DROP DATABASE duynhlab_auth;"   # … per service
 | `db-setup bootstrap` errors `SUPERUSER_DSN` | Env var not exported | `export SUPERUSER_DSN=postgresql://postgres:…` |
 | `db-setup` errors `DB_PASSWORD empty` | Env file not generated | Reinstall, or run `duynhlab-gen-password` |
 
-See [install.md](install.md) for first-time setup and [architecture.md](architecture.md)
+See [install.md](002-install.md) for first-time setup and [architecture.md](001-architecture.md)
 for the systemd/DB model.

--- a/docs/004-build.md
+++ b/docs/004-build.md
@@ -155,7 +155,7 @@ make release        # computes next free tag (v2026.06.11 → v2026.06.11.1 …)
 ```
 
 Full operational runbook (same-day hotfix, re-publishing a tag, rollback,
-auditing a release's composition): [`release.md`](release.md).
+auditing a release's composition): [`005-release.md`](005-release.md).
 
 > **Critical ordering**: `stage-all.sh` must run before `build-rpm.sh` — the
 > spec's `Source0` is the staging tarball. Every build workflow includes that

--- a/docs/005-release.md
+++ b/docs/005-release.md
@@ -2,7 +2,7 @@
 
 Operational guide for cutting, re-publishing, rolling back, and auditing
 releases. Pipeline internals (scripts, workflows, hosting rationale):
-[`build.md`](build.md) § 5.
+[`004-build.md`](004-build.md) § 5.
 
 ## 1. Flow at a glance
 
@@ -85,7 +85,7 @@ Older than that: download from the
 > ⚠️ Migrations are **forward-only** — downgrading the package does not
 > downgrade the schema. Only downgrade across versions with the same
 > `SCHEMA_VERSION` (check the release notes / manifest), or restore the DB from
-> a pre-upgrade backup. See [`install.md`](install.md) § Downgrade.
+> a pre-upgrade backup. See [`002-install.md`](002-install.md) § Downgrade.
 
 ## 6. Audit a release
 

--- a/docs/006-add-service.md
+++ b/docs/006-add-service.md
@@ -1,0 +1,122 @@
+# Adding a New Service
+
+How to onboard a new backend service (example used throughout: `payments`,
+HTTP port **8009**) into the mega-RPM. [`services.yaml`](../services.yaml) is
+the declared source of truth, but several places still hardcode the service
+list — §3 is the honest checklist of every one of them.
+
+## 1. Service repo prerequisites
+
+The packages repo only *repacks* — the service repo must follow the duynhlab
+conventions or the pipeline can't build/run it:
+
+- **Go service** with `main` at `./cmd` (overridable via `build_path`), builds
+  with `CGO_ENABLED=0 GOOS=linux GOARCH=amd64`.
+- **Migrations embedded in the binary**: `db/migrations/sql/000NNN_*.up.sql`
+  (forward-only, no `.down.sql`), embedded via `//go:embed` and applied by the
+  binary's own `migrate` subcommand through `github.com/duynhlab/pkg/migratex`.
+  `duynhlab-db-setup migrate payments` execs exactly that.
+- **Config via discrete env vars** (no `DATABASE_URL`): `DB_HOST DB_PORT
+  DB_NAME DB_USER DB_PASSWORD DB_SSLMODE`, plus `PORT` (and `GRPC_PORT` if it
+  serves gRPC). Defaults of 8080/9090 in code are fine — the RPM overrides
+  them per service.
+- **`GET /health`** returning 200 on the HTTP port — `duynhlab-ctl health` and
+  the integration test poll it.
+- Logs to stdout/stderr (journald captures them).
+
+## 2. The declarative step — `services.yaml`
+
+```yaml
+  - name: payments
+    repo: duynhlab/payments-service
+    src_dir: payments-service
+    binary: payments-service
+    build_path: ./cmd
+    port: 8009
+    # grpc_port: 9009        # only if it runs a gRPC server
+    type: backend
+    database:
+      name: duynhlab_payments
+      app_user: duynhlab_payments_app
+      migrator_user: duynhlab_payments_migrator
+    dependencies:
+      after: []
+      env_files: []
+```
+
+This alone makes the **dynamic** parts pick the service up (see §4).
+
+## 3. The hardcoded touch points — checklist
+
+> These are known SSOT gaps (see the automation backlog note in §7). Until they
+> are generated from `services.yaml`, every new service must edit ALL of them.
+> Line numbers are indicative — search for the 8-service list nearby.
+
+| # | File | Where | What to add |
+|---|---|---|---|
+| 1 | `specs/duynhlab.spec` | `%check` ELF loop (~106) | `payments` in the `for svc in …` list |
+| 2 | `specs/duynhlab.spec` | `%post` systemd preset loop (~151) | same |
+| 3 | `specs/duynhlab.spec` | `%post` first-install hint heredoc (~170) | same (cosmetic) |
+| 4 | `specs/duynhlab.spec` | `%preun` stop loop (~196) | same |
+| 5 | `specs/duynhlab.spec` | `%postun` restart loop (~207) | same |
+| 6 | `specs/duynhlab.spec` | `%files` payload dirs (~219) | `%{duynhlab_prefix}/payments` |
+| 7 | `specs/duynhlab.spec` | `%files` ghost env list (~262) | `%ghost %attr(0640, root, %{duynhlab_group}) %{duynhlab_etc}/payments.env` |
+| 8 | `packages/rpm/lib/init-service.sh` | `BACKENDS` array (~19) | `payments` |
+| 9 | `packages/rpm/secret-tpl/payments.env.tpl` | **new file** | copy `auth.env.tpl`, set `SERVICE_NAME`/`PORT=8009`/(`GRPC_PORT`)/`DB_NAME=duynhlab_payments`/`DB_USER=duynhlab_payments_app`/migrator names; keep `__DB_PASSWORD__` placeholders |
+| 10 | `scripts/test-integration.sh` | `BACKENDS` array (~50) | `payments` |
+| 11 | `scripts/test-integration.sh` | `PORTS` map (~51) | `[payments]=8009` |
+| 12 | `scripts/test-integration.sh` | pod port-publish loop (~78) | `8009` |
+| 13 | `scripts/test-install.sh` | binary-check loop (~62), `expected_services` (~107), env-file loop (~122), log-dir loop (~148) | `payments` in all four |
+| 14 | `packages/rpm/nginx/duynhlab.conf` | upstream block (~5) + location block (~50) | `upstream duynhlab_payments { server 127.0.0.1:8009; }` and `location /api/payments/ { proxy_pass http://duynhlab_payments/; }` |
+
+Grep guard before committing — every hardcoded list should now contain the new
+name:
+
+```bash
+grep -rn "notification shipping" specs/ scripts/ packages/ | grep -v payments && echo "MISSED A SPOT" || echo OK
+```
+
+## 4. What you do NOT touch (dynamic — driven by services.yaml)
+
+`fetch-sources.sh`, `build-local.sh`, `render-systemd.sh` (unit + platform
+target), `stage-all.sh` (staging + composition manifest), `Makefile
+build-local-all`, `duynhlab-ctl` (list/health/ports), `password-generator.sh`
+(scans `secret-tpl/*.env.tpl`), `duynhlab-db-setup` (per-service args),
+`bootstrap.sql`. They all iterate the registry — no edits needed.
+
+## 5. Build & verify locally
+
+```bash
+make fetch-sources                      # clones payments-service alongside
+make build-local SERVICE=payments       # binary tarball + build-info.env
+make build-local-all                    # or rebuild everything
+make build                              # mega-RPM with payments inside
+make test-install                       # asserts the new loops you edited in §3
+make test-integration                   # boots all backends incl. payments, /health ×9
+```
+
+`test-install` failing on a missing binary/env/unit usually means you missed a
+§3 touch point — the error names the file.
+
+## 6. Database + first run, then ship
+
+On a test host (or in the integration container):
+
+```bash
+SUPERUSER_DSN="postgresql://postgres:…@localhost:5432/postgres" \
+  sudo -E duynhlab-db-setup bootstrap payments
+sudo duynhlab-db-setup migrate payments
+sudo systemctl start duynhlab-payments && curl -fsS localhost:8009/health
+```
+
+Ship: open the PR (CI runs the same `test-install`; the integration test runs
+after merge), then cut a release per [`005-release.md`](005-release.md) —
+`make release`. The new service appears in the release's composition manifest
+automatically.
+
+## 7. Automation note
+
+Touch points 1–8 and 10–14 exist because the spec/test/nginx files predate the
+registry. Generating them from `services.yaml` is tracked in the internal
+backlog (`plan-spec.md` B5 render-nginx + B16 render hardcoded lists). If you
+automate one of them, delete its row from §3.

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,18 +3,21 @@
 Distribution layer that repacks the upstream `duynhlab/*-service` binaries into a
 single **mega-RPM** and serves it from a YUM repository on GitHub Pages.
 
-Start with the repo [`README.md`](../README.md) for the high-level overview, then
-pick the guide that matches your task.
+Start with the repo [`README.md`](../README.md) for the high-level overview.
+The docs are numbered as a reading order — **understand → install → operate →
+build → release → extend** — but each guide stands alone, so jump straight to
+the one that matches your task.
 
 ## Index
 
-| Document | Audience | Contents |
-|---|---|---|
-| [`install.md`](install.md) | Operators installing the RPM | Add the repo, install, bootstrap the database, start, upgrade, remove, troubleshooting |
-| [`architecture.md`](architecture.md) | Anyone | Why a mega-RPM, component map, services table, FHS layout, systemd model, install/upgrade/remove lifecycle diagrams, database model |
-| [`build.md`](build.md) | Contributors / release engineers | Build pipeline, scripts, runner auto-detection, Makefile targets, CI workflows, gh-pages publishing, versioning, adding a service |
-| [`release.md`](release.md) | Release engineers | Runbook: cut a release, same-day hotfix, re-publish a tag, rollback/downgrade, audit composition, troubleshooting per job |
-| [`operations.md`](operations.md) | Operators (day-2) | `duynhlab-ctl` and `duynhlab-db-setup` reference, bring-up flow, systemd targets, configuration files, upgrade, remove, troubleshooting |
+| # | Document | Audience | Contents |
+|---|---|---|---|
+| 001 | [`001-architecture.md`](001-architecture.md) | Anyone | Why a mega-RPM, component map, services table, FHS layout, systemd model, install/upgrade/remove lifecycle diagrams, database model |
+| 002 | [`002-install.md`](002-install.md) | Operators installing the RPM | Add the repo, install, bootstrap the database, start, upgrade, downgrade, remove, troubleshooting |
+| 003 | [`003-operations.md`](003-operations.md) | Operators (day-2) | `duynhlab-ctl` and `duynhlab-db-setup` reference, bring-up flow, systemd targets, configuration files, upgrade, remove, troubleshooting |
+| 004 | [`004-build.md`](004-build.md) | Contributors / release engineers | Build pipeline, scripts, runner auto-detection, Makefile targets, CI workflows, gh-pages publishing, versioning |
+| 005 | [`005-release.md`](005-release.md) | Release engineers | Runbook: cut a release, same-day hotfix, re-publish a tag, rollback/downgrade, audit composition, troubleshooting per job |
+| 006 | [`006-add-service.md`](006-add-service.md) | Contributors | Onboard a new service: repo prerequisites, `services.yaml` entry, the full hardcoded touch-point checklist, verify, ship |
 
 ## Conventions used in these docs
 

--- a/scripts/publish-yum-repo.sh
+++ b/scripts/publish-yum-repo.sh
@@ -212,7 +212,7 @@ sudo curl -fsSL -o /etc/yum.repos.d/duynhlab.repo $BASE_URL/duynhlab.repo
 sudo dnf install -y duynhlab
 \`\`\`
 
-See [\`docs/install.md\`](https://github.com/duynhlab/packages/blob/main/docs/install.md)
+See [\`docs/002-install.md\`](https://github.com/duynhlab/packages/blob/main/docs/002-install.md)
 for the full guide.
 EOF
 


### PR DESCRIPTION
## What

### Numbered reading order (user-chosen: architecture-first)

```
docs/README.md           index (unnumbered)
001-architecture.md      understand the system
002-install.md           install it
003-operations.md        run it day-2
004-build.md             build the RPM
005-release.md           ship a release
006-add-service.md       extend the platform   ← NEW
```

`git mv` (history preserved); **all 19 cross-references** updated — README, every docs cross-link, AGENTS.md layout line, and the gh-pages README heredoc in `publish-yum-repo.sh` (absolute GitHub URL). Link-checker loop over every `](*.md)` passes.

### New: `006-add-service.md` — onboarding a new service

The old `build.md` §7 covered 3 of the steps. An agent inventory found **14 hardcoded touch points** it missed. The new guide has:
- Service-repo prerequisites (embedded migrations via `pkg/migratex` + `migrate` subcommand, `PORT`/`GRPC_PORT`/`DB_*` env, `/health`)
- The `services.yaml` entry (worked `payments` example)
- The **complete touch-point checklist**: 7 spots in `specs/duynhlab.spec` (%check/%post/%preun/%postun loops, %files, %ghost), `init-service.sh` BACKENDS, a new `secret-tpl/*.env.tpl`, 3 spots in `test-integration.sh`, 4 loops in `test-install.sh`, nginx upstream+location — each with a grep guard
- What is **dynamic** (services.yaml-driven, no edits): render-systemd, stage-all + manifest, ctl, password-generator, db-setup…
- Local verify (`make build test-install test-integration`) and shipping via `make release`
- Automation note → backlog B16 ("render the hardcoded lists from services.yaml")

`build.md` §7 now just links to 006.

> Touches `scripts/publish-yum-repo.sh` (one URL in a heredoc), so the PR build runs.