### PR TITLE
docs: clarify yq is a build-time dep, distinct from the spec's Requires

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,6 +192,9 @@ come pre-built from the service repos.
 - **`duynhlab-ctl`'s `yq` comes via `Requires: yq >= 4`** (EPEL ships mikefarah yq ≥4.47 on EL9 —
   historically it was the unrelated python-yq, so re-verify if the floor ever changes). Don't bundle
   a private copy; the ctl resolver prefers `/opt/duynhlab/lib/yq` only as an escape hatch (B6).
+  **Build machines need mikefarah yq too** (`yq_bin()` in `scripts/lib/common.sh` parses
+  `services.yaml` during builds) — the spec's `Requires:` does NOT cover them; CI installs it in
+  `_build-test.yml`, devs install it once. Don't delete `yq_bin()` thinking the spec replaced it.
 - **Frontend `VITE_API_BASE_URL` is baked at build time** — changing the gateway origin requires a
   rebuild.
 - **Never co-locate two services in one database** — golang-migrate's unqualified `schema_migrations`

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -34,7 +34,15 @@ require_cmd() {
   done
 }
 
-# ── services.yaml parser (uses yq v4) ─────────────────────────────────────────
+# ── services.yaml parser (mikefarah yq v4) ────────────────────────────────────
+# BUILD-TIME dependency — runs on the developer machine / CI runner that BUILDS
+# the RPM. Do not confuse it with the spec's `Requires: yq`, which only applies
+# to CUSTOMER hosts that INSTALL the RPM (it covers duynhlab-ctl at runtime and
+# does nothing for build machines).
+#   CI:  installed by .github/workflows/_build-test.yml (curl from GitHub —
+#        Ubuntu's `apt install yq` is the unrelated python-yq, wrong tool).
+#   Dev: install once: `go install github.com/mikefarah/yq/v4@latest` or grab
+#        the binary from https://github.com/mikefarah/yq/releases.
 yq_bin() {
   if command -v yq >/dev/null 2>&1; then
     echo yq


### PR DESCRIPTION
## Why

A review question ("we moved yq into the spec — why does `yq_bin()` still exist?") revealed the distinction isn't documented anywhere:

| | Runs on | Covered by |
|---|---|---|
| **Runtime** — `duynhlab-ctl` parsing `/etc/duynhlab/services.yaml` | customer hosts (installed RPM) | `Requires: yq >= 4` (EPEL) — B6 ✅ |
| **Build-time** — `yq_bin()` → `svc_list`/`svc_field` parsing `services.yaml` | dev machines / CI runners **building** the RPM | NOT the spec — RPM deps don't apply to build machines |

Deleting `yq_bin()` would break `build-local.sh`, `render-systemd.sh`, `stage-all.sh`, `fetch-sources.sh`, the Makefile loop, and both workflows. (A python3 replacement was considered and declined — keeping yq, documenting the split.)

## What

Comment-only:
- `scripts/lib/common.sh`: block above `yq_bin()` explaining build-time vs runtime, where CI installs it (`_build-test.yml`), why it's curled (Ubuntu's `apt yq` is the unrelated python-yq), and the dev install one-liner.
- `AGENTS.md`: extend the yq gotcha — "Build machines need mikefarah yq too… Don't delete `yq_bin()` thinking the spec replaced it."

No logic changes; `bash -n` + `svc_list` smoke-checked.