### PR TITLE
feat: incremental secret versioning, support-bundle, install history

### DIFF
--- a/docs/002-install.md
+++ b/docs/002-install.md
@@ -175,6 +175,11 @@ sudo -u postgres psql -c "DROP DATABASE duynhlab_auth;" ...
 
 ## Troubleshooting
 
+When contacting support, attach a diagnostics bundle —
+`sudo duynhlab-ctl support-bundle` collects journals, unit status, versions and
+non-secret configs into one tarball (**your `*.env` secrets are never
+included**).
+
 | Symptom | Likely cause | Fix |
 |---|---|---|
 | `dnf install` fails: `Curl error (60): SSL certificate problem` | Mirror reach is restricted | `dnf install --setopt=sslverify=false` once, then fix CA |

--- a/docs/003-operations.md
+++ b/docs/003-operations.md
@@ -29,6 +29,7 @@ duynhlab-ctl <command> [svc|all] [args]
 | `version` | `duynhlab-ctl version all` | Print binary + schema versions |
 | `config` | `duynhlab-ctl config auth` | Show env file (password masked) |
 | `ports` | `duynhlab-ctl ports` | Port assignment table |
+| `support-bundle` | `duynhlab-ctl support-bundle [dir]` | Diagnostics tarball for support: 7 days of journals, unit status, manifest, versions, install history, non-secret configs. **`*.env` / `*.override` are never included** |
 
 `svc` accepts a single name or `all`. Health/version iterate every service.
 

--- a/packages/common/scripts/duynhlab-ctl
+++ b/packages/common/scripts/duynhlab-ctl
@@ -14,6 +14,7 @@
 #   version  <svc|all>          Print binary + schema versions
 #   config   <svc>              cat env file (masked password)
 #   ports    [filter]           Show port assignments
+#   support-bundle [dir]        Collect logs+configs for support (NO secrets)
 set -euo pipefail
 
 PROG=${0##*/}
@@ -110,6 +111,54 @@ cmd_config() {
   sed 's/\(DB_PASSWORD=\).*/\1********/' "$f"
 }
 
+# Collect a diagnostics tarball for support. SECRETS ARE NEVER INCLUDED:
+# <svc>.env and <svc>.override are excluded wholesale (they carry DB passwords).
+cmd_support_bundle() {
+  require_yq
+  local outdir=${1:-/tmp}
+  local version stamp work name
+  version=$(sed -n 's/^DUYNHLAB_VERSION=//p' "$ETC_BASE/env-global.properties" 2>/dev/null | head -1)
+  [ -n "$version" ] || version=unknown
+  stamp=$(date -u +%Y%m%dT%H%M%SZ)
+  name="duynhlab-support-${version}-${stamp}"
+  work=$(mktemp -d)
+  # Expand $work NOW — a deferred '$work' would be out of scope (set -u) at exit.
+  trap "rm -rf '$work'" EXIT
+  mkdir -p "$work/$name"/{journal,etc,opt}
+
+  echo "Collecting (secrets are NOT included)..."
+  # Per-service journal (last 7 days) + unit status.
+  while read -r svc; do
+    journalctl -u "duynhlab-$svc" --since '7 days ago' --no-pager \
+      > "$work/$name/journal/duynhlab-$svc.log" 2>&1 || :
+    systemctl status "duynhlab-$svc" --no-pager \
+      > "$work/$name/journal/duynhlab-$svc.status" 2>&1 || :
+  done < <(list_services)
+
+  # Platform state.
+  { cmd_list; echo; cmd_ports ""; } > "$work/$name/platform-state.txt" 2>&1 || :
+  systemctl list-units 'duynhlab-*' --all --no-pager \
+    > "$work/$name/units.txt" 2>&1 || :
+
+  # Versions + composition (no secrets in any of these).
+  cp -f "$OPT_BASE/etc/manifest"        "$work/$name/opt/manifest"        2>/dev/null || :
+  cp -f /var/log/duynhlab/version.log   "$work/$name/install-history.log" 2>/dev/null || :
+  for d in "$OPT_BASE"/*/BINARY_VERSION; do
+    [ -f "$d" ] || continue
+    printf '%s: %s\n' "$(basename "$(dirname "$d")")" "$(cat "$d")"
+  done > "$work/$name/opt/binary-versions.txt" 2>/dev/null || :
+
+  # Non-secret configs only. .env/.override are deliberately skipped.
+  cp -f "$ETC_BASE/services.yaml"          "$work/$name/etc/" 2>/dev/null || :
+  cp -f "$ETC_BASE/env-global.properties"  "$work/$name/etc/" 2>/dev/null || :
+  cp -f /etc/nginx/conf.d/duynhlab.conf    "$work/$name/etc/" 2>/dev/null || :
+
+  local out="$outdir/$name.tar.gz"
+  tar -C "$work" -czf "$out" "$name"
+  echo "${C_GRN}Support bundle: $out${C_RST}"
+  echo "Secrets (*.env, *.override) are NOT included. Attach this file to your support request."
+}
+
 cmd_ports() {
   require_yq
   local filter=${1:-}
@@ -119,7 +168,7 @@ cmd_ports() {
 }
 
 usage() {
-  sed -n '3,16p' "$0" | sed 's/^# \{0,1\}//'
+  sed -n '3,17p' "$0" | sed 's/^# \{0,1\}//'
   exit 2
 }
 
@@ -139,6 +188,7 @@ case "$CMD" in
   config)             [[ $# -ge 1 ]] || die "usage: $PROG config <svc>"
                       cmd_config "$1" ;;
   ports)              cmd_ports "${1:-}" ;;
+  support-bundle)     cmd_support_bundle "${1:-/tmp}" ;;
   -h|--help|help)     usage ;;
   *)                  die "Unknown command: $CMD (try '$PROG help')" ;;
 esac

--- a/packages/common/scripts/duynhlab-ctl.bash-completion
+++ b/packages/common/scripts/duynhlab-ctl.bash-completion
@@ -3,7 +3,7 @@ _duynhlab_ctl() {
   local cur prev words cword
   _init_completion || return
 
-  local cmds="list start stop restart enable disable status logs health version config ports help"
+  local cmds="list start stop restart enable disable status logs health version config ports support-bundle help"
   if [[ $cword -eq 1 ]]; then
     COMPREPLY=( $(compgen -W "$cmds" -- "$cur") )
     return

--- a/packages/rpm/duynhlab.spec
+++ b/packages/rpm/duynhlab.spec
@@ -138,12 +138,18 @@ if [ -x %{duynhlab_prefix}/lib/init-service.sh ]; then
   %{duynhlab_prefix}/lib/init-service.sh || :
 fi
 
-# 2. On first install only: generate env files with random passwords.
-if [ $1 -eq 1 ]; then
-  if [ -x %{duynhlab_prefix}/lib/password-generator.sh ]; then
-    %{duynhlab_prefix}/lib/password-generator.sh || :
-  fi
+# 2. Generate/upgrade env files. Runs on EVERY install AND upgrade: the
+# generator is versioned via /etc/duynhlab/secret_version.properties, so a
+# release that introduces a new secret applies only its own incremental block
+# — existing env files and passwords are never touched.
+if [ -x %{duynhlab_prefix}/lib/password-generator.sh ]; then
+  %{duynhlab_prefix}/lib/password-generator.sh || :
 fi
+
+# 2b. Append to the install history (support: "what versions ran on this box?").
+mkdir -p %{duynhlab_log}
+echo "%{version}-%{release} installed on $(date -u +%%Y-%%m-%%dT%%H:%%M:%%SZ) (op=$1)" \
+  >> %{duynhlab_log}/version.log
 
 # 3. systemd_post for every shipped unit.
 %systemd_post duynhlab-platform.target
@@ -272,4 +278,3 @@ exit 0
 * Sun May 24 2026 duynhlab ops <ops@duynhlab.io> - 2026.05.20-1
 - Initial mega-RPM release (Option A monorepo SPEC).
 - 8 backend services + frontend + common CLI in a single package.
-- Inspired by Opswat MOCM packaging pattern.

--- a/packages/rpm/lib/password-generator.sh
+++ b/packages/rpm/lib/password-generator.sh
@@ -1,17 +1,27 @@
 #!/usr/bin/env bash
-# password-generator.sh — generate /etc/duynhlab/<svc>.env on first install.
+# password-generator.sh — generate /etc/duynhlab/<svc>.env files.
 #
 # - Reads templates from /opt/duynhlab/secret-tpl/<svc>.env.tpl
 # - Substitutes __DB_PASSWORD__ with a fresh 32-char random string per service
 # - Writes /etc/duynhlab/<svc>.env mode 0640 root:duynhlab
 # - Idempotent: never overwrites an existing env file
-# - Tracks state via /etc/duynhlab/secret_version.properties
+#
+# INCREMENTAL VERSIONING:
+# /etc/duynhlab/secret_version.properties records the highest version block
+# that has completed. %post calls this script on EVERY install AND upgrade;
+# blocks below run only when their version is newer than the recorded one,
+# so a future release can ADD a new secret without re-initializing old ones.
+#
+# To add a secret in a future release:
+#   1. add an `if [ "$have" -lt N ]; then … fi` block below (N = next number)
+#   2. bump CURRENT_SECRET_VERSION to N
+# Per-file `[ -f "$env_file" ] && continue` guards stay as a second safety net.
 set -eu
 
 ETC=/etc/duynhlab
 TPL=/opt/duynhlab/secret-tpl
 STATE_FILE="$ETC/secret_version.properties"
-SECRET_VERSION=1
+CURRENT_SECRET_VERSION=1
 
 GEN_PASS=/opt/duynhlab/lib/duynhlab-gen-password
 GEN_ENV=/opt/duynhlab/lib/duynhlab-gen-env
@@ -21,45 +31,55 @@ log() { printf '[password-generator] %s\n' "$*"; }
 mkdir -p "$ETC"
 chmod 0755 "$ETC"
 
+have=0
 if [ -f "$STATE_FILE" ]; then
   # shellcheck disable=SC1090
   . "$STATE_FILE"
-  if [ "${secretVersion:-0}" -ge "$SECRET_VERSION" ]; then
-    log "secrets already initialized (version=$secretVersion); nothing to do"
-    exit 0
-  fi
+  have="${secretVersion:-0}"
 fi
 
-for tpl in "$TPL"/*.env.tpl; do
-  [ -f "$tpl" ] || continue
-  svc=$(basename "$tpl" .env.tpl)
-  env_file="$ETC/$svc.env"
+if [ "$have" -ge "$CURRENT_SECRET_VERSION" ]; then
+  log "secrets already at version $have; nothing to do"
+  exit 0
+fi
 
-  if [ -f "$env_file" ]; then
-    log "preserving existing $env_file"
-    continue
-  fi
+# ── v1: initial per-service env files (8 backends) ───────────────────────────
+if [ "$have" -lt 1 ]; then
+  log "applying secret version 1 (initial env generation)"
+  for tpl in "$TPL"/*.env.tpl; do
+    [ -f "$tpl" ] || continue
+    svc=$(basename "$tpl" .env.tpl)
+    env_file="$ETC/$svc.env"
 
-  if [ -x "$GEN_ENV" ]; then
-    "$GEN_ENV" "$svc"
-  else
-    # Inline fallback if duynhlab-gen-env is missing.
-    pass=$("$GEN_PASS" 32 2>/dev/null || \
-           tr -dc 'A-Za-z0-9' </dev/urandom 2>/dev/null | head -c 32)
-    sed "s/__DB_PASSWORD__/${pass}/g" "$tpl" > "$env_file"
-    chown root:duynhlab "$env_file" 2>/dev/null || :
-    chmod 0640 "$env_file"
-    log "generated $env_file"
-  fi
-done
+    if [ -f "$env_file" ]; then
+      log "preserving existing $env_file"
+      continue
+    fi
+
+    if [ -x "$GEN_ENV" ]; then
+      "$GEN_ENV" "$svc"
+    else
+      # Inline fallback if duynhlab-gen-env is missing.
+      pass=$("$GEN_PASS" 32 2>/dev/null || \
+             tr -dc 'A-Za-z0-9' </dev/urandom 2>/dev/null | head -c 32)
+      sed "s/__DB_PASSWORD__/${pass}/g" "$tpl" > "$env_file"
+      chown root:duynhlab "$env_file" 2>/dev/null || :
+      chmod 0640 "$env_file"
+      log "generated $env_file"
+    fi
+  done
+fi
+
+# ── v2, v3, …: future releases add new blocks here (see header) ──────────────
 
 cat > "$STATE_FILE" <<EOF
-# Tracks which secret-generation version has run.
-# Bump SECRET_VERSION in password-generator.sh to force re-init.
-secretVersion=$SECRET_VERSION
+# Tracks which secret-generation version has completed (see
+# password-generator.sh — new releases append numbered blocks there).
+secretVersion=$CURRENT_SECRET_VERSION
 generatedAt=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 EOF
-chmod 0644 "$STATE_FILE"
+chown root:duynhlab "$STATE_FILE" 2>/dev/null || :
+chmod 0640 "$STATE_FILE"
 
-log "done"
+log "done (secret version $CURRENT_SECRET_VERSION)"
 exit 0

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -102,6 +102,38 @@ duynhlab-ctl list
 duynhlab-ctl ports
 echo "::endgroup::"
 
+echo "::group::secret versioning — re-running the generator must change nothing"
+grep -q "^secretVersion=1$" /etc/duynhlab/secret_version.properties \
+  || { echo "BAD secret_version.properties"; exit 1; }
+stat -c '%a' /etc/duynhlab/secret_version.properties | grep -qx 640 \
+  || { echo "secret_version.properties not 0640"; exit 1; }
+before=$(sha256sum /etc/duynhlab/*.env | sha256sum)
+/opt/duynhlab/lib/password-generator.sh
+after=$(sha256sum /etc/duynhlab/*.env | sha256sum)
+[ "$before" = "$after" ] || { echo "GENERATOR NOT IDEMPOTENT — env files changed"; exit 1; }
+echo "idempotent OK"
+echo "::endgroup::"
+
+echo "::group::install history log"
+grep -q "installed on" /var/log/duynhlab/version.log \
+  || { echo "MISSING version.log entry"; exit 1; }
+cat /var/log/duynhlab/version.log
+echo "::endgroup::"
+
+echo "::group::support-bundle contains NO secrets"
+duynhlab-ctl support-bundle /tmp
+bundle=$(ls /tmp/duynhlab-support-*.tar.gz | head -1)
+[ -f "$bundle" ] || { echo "NO bundle produced"; exit 1; }
+# Take a real password value and prove it is absent from the bundle.
+pass=$(grep -m1 '^DB_PASSWORD=' /etc/duynhlab/auth.env | cut -d= -f2)
+mkdir -p /tmp/bundle-x && tar -xzf "$bundle" -C /tmp/bundle-x
+if grep -r -q "$pass" /tmp/bundle-x; then
+  echo "SECRET LEAKED INTO SUPPORT BUNDLE"; exit 1
+fi
+ls /tmp/bundle-x/*/ | head -10
+echo "no secrets in bundle OK"
+echo "::endgroup::"
+
 echo "::group::systemd units"
 ls /usr/lib/systemd/system/duynhlab-*.{service,target}
 expected_services="auth user product cart order review notification shipping"


### PR DESCRIPTION
## Why

Hardening the package for customer self-host installs: when something breaks on a box we don't control, support needs (a) safe secret evolution across upgrades, (b) one command to collect diagnostics, (c) a record of what versions ran there. (`systemd-creds` encryption-at-rest was deliberately deferred to the backlog with a ready design.)

## What

### 1. Incremental secret versioning
`password-generator.sh` restructured into numbered blocks gated by `secretVersion < N`; **`%post` now runs it on every install AND upgrade** (previously first-install only). A future release that adds a new secret ships its own block + bumps `CURRENT_SECRET_VERSION` — existing env files/passwords are never touched (per-file guards stay as a second net). `secret_version.properties` → `0640 root:duynhlab`.

> Semantics change called out explicitly: the generator is now invoked on upgrades — safe because it is version-gated and per-file-guarded; the new idempotency assertion proves it.

### 2. `duynhlab-ctl support-bundle [dir]`
One tarball for support: 7-day per-service journals, unit status, composition manifest, binary versions, install history, non-secret configs. **`*.env` / `*.override` excluded wholesale** — and the install test *proves* it by extracting the bundle and grepping for a real `DB_PASSWORD` value.

### 3. Install history log
`%post` appends `<version> installed on <ts> (op=$1)` to `/var/log/duynhlab/version.log` — "what versions ran on this box?" answered in one `cat`. Survives uninstall by design.

## Verification

`make build` + `make test-install` green with three new assertion groups:
- re-running the generator changes nothing (env sha256 identical)
- `version.log` contains the install entry
- the support bundle contains **no secret values**

Docs updated (`002-install` troubleshooting intro, `003-operations` ctl table); bash-completion includes the new subcommand.