### PR TITLE
refactor!: rename CLI tools to short names (duynhctl, duynhdb, duynhenv, duynhpass)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ scripts/                       Build / render / ops scripts
 ├── publish-yum-repo.sh        createrepo_c → gh-pages YUM metadata
 └── test-install.sh / test-integration.sh   install / integration tests
 packages/
-├── common/scripts/            duynhlab-ctl, duynhlab-db-setup, duynhlab-gen-env, duynhlab-gen-password
+├── common/scripts/            duynhctl, duynhdb, duynhenv, duynhpass
 └── rpm/
     ├── duynhlab.spec          The mega-RPM SPEC (rpmbuild) — lives with the assets it packages
     ├── systemd/               duynhlab-service.tmpl.service, *.target(.tmpl)
@@ -85,8 +85,8 @@ independent per-service versioning.
 
 - Payload lands under `/opt/duynhlab/` (immutable, replaced each upgrade).
 - CLI tooling ships to `/opt/duynhlab/lib/` with `/usr/bin/` symlinks:
-  `duynhlab-ctl` (service ops), `duynhlab-db-setup` (DB bootstrap/migrate/status),
-  `duynhlab-gen-env`, `duynhlab-gen-password`.
+  `duynhctl` (service ops), `duynhdb` (DB bootstrap/migrate/status),
+  `duynhenv`, `duynhpass`.
 - systemd: each `duynhlab-<svc>.service` is `PartOf=duynhlab-platform.target` and ordered
   `After=duynhlab-infra.target` (which `Wants=` external `nginx`/`postgresql`/`valkey`).
 - Each unit loads env in order: `env-global.properties` → `<svc>.env` (required) → `<svc>.override`.
@@ -151,13 +151,13 @@ come pre-built from the service repos.
   `duynhlab_<svc>_app` (runtime CRUD), `duynhlab_<svc>_migrator` (DDL).
 - **Migrations:** embedded in each service binary (`//go:embed`, golang-migrate v4 via
   `duynhlab/pkg/migratex`, forward-only `000NNN_*.up.sql`). Run by the binary itself:
-  `duynhlab-db-setup <svc> migrate` execs `/opt/duynhlab/<svc>/bin/<binary> migrate`. This repo ships
+  `duynhdb <svc> migrate` execs `/opt/duynhlab/<svc>/bin/<binary> migrate`. This repo ships
   **no** loose SQL and **no** separate migrate tool (D23/D24).
 - **Env vars:** `DB_HOST DB_PORT DB_NAME DB_USER DB_PASSWORD DB_SSLMODE DB_POOL_*`, plus `PORT` and (for
   gRPC services) `GRPC_PORT`. No `DATABASE_URL`. `secret-tpl/<svc>.env.tpl` uses the `__DB_PASSWORD__`
   placeholder, substituted at install.
-- **Ops CLI:** `duynhlab-ctl {list,start,stop,restart,status,enable,disable,logs,health,version,config,ports}`;
-  `duynhlab-db-setup <svc> {bootstrap,migrate,status}` (`bootstrap` needs `SUPERUSER_DSN`).
+- **Ops CLI:** `duynhctl {list,start,stop,restart,status,enable,disable,logs,health,version,config,ports}`;
+  `duynhdb <svc> {bootstrap,migrate,status}` (`bootstrap` needs `SUPERUSER_DSN`).
 
 ## Testing
 
@@ -189,7 +189,7 @@ come pre-built from the service repos.
 - **Every service defaults to HTTP `8080` and gRPC `9090` in code.** On a shared host they collide, so
   `PORT`/`GRPC_PORT` MUST be set per service from `services.yaml` (`port`, `grpc_port`).
 - **Env path is flat:** `/etc/duynhlab/<svc>.env`.
-- **`duynhlab-ctl`'s `yq` comes via `Requires: yq >= 4`** (EPEL ships mikefarah yq ≥4.47 on EL9 —
+- **`duynhctl`'s `yq` comes via `Requires: yq >= 4`** (EPEL ships mikefarah yq ≥4.47 on EL9 —
   historically it was the unrelated python-yq, so re-verify if the floor ever changes). Don't bundle
   a private copy; the ctl resolver prefers `/opt/duynhlab/lib/yq` only as an escape hatch (B6).
   **Build machines need mikefarah yq too** (`yq_bin()` in `scripts/lib/common.sh` parses

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ sudo dnf install -y duynhlab
 ```
 
 Then bootstrap the per-service databases and start the platform — full steps
-(prerequisites, per-service `duynhlab-db-setup bootstrap`/`migrate`, verify,
+(prerequisites, per-service `duynhdb bootstrap`/`migrate`, verify,
 upgrade, remove): [`docs/002-install.md`](docs/002-install.md).
 
 ### Build locally (maintainer)
@@ -57,7 +57,7 @@ releases**, so `dnf downgrade duynhlab` works. Details + rationale:
 |---|---|
 | [`docs/001-architecture.md`](docs/001-architecture.md) | What ships in the package, FHS layout, systemd model, lifecycle |
 | [`docs/002-install.md`](docs/002-install.md) | End-user install, bootstrap, upgrade, downgrade, remove, troubleshooting |
-| [`docs/003-operations.md`](docs/003-operations.md) | `duynhlab-ctl`, `duynhlab-db-setup`, systemd targets, day-2 ops |
+| [`docs/003-operations.md`](docs/003-operations.md) | `duynhctl`, `duynhdb`, systemd targets, day-2 ops |
 | [`docs/004-build.md`](docs/004-build.md) | Build pipeline, scripts, Makefile, CI workflows, publishing |
 | [`docs/005-release.md`](docs/005-release.md) | Release runbook: cut, same-day hotfix, re-publish, rollback, audit |
 | [`docs/006-add-service.md`](docs/006-add-service.md) | Onboarding a new service: prerequisites, registry entry, touch-point checklist |

--- a/docs/001-architecture.md
+++ b/docs/001-architecture.md
@@ -34,7 +34,7 @@ flowchart TB
       ETCMETA["etc/services.yaml<br/>etc/env-global.properties"]
     end
     UNITS["systemd units<br/>duynhlab-&lt;svc&gt;.service ×8<br/>duynhlab-platform.target<br/>duynhlab-infra.target"]
-    BIN["/usr/bin symlinks<br/>duynhlab-ctl, duynhlab-db-setup, …"]
+    BIN["/usr/bin symlinks<br/>duynhctl, duynhdb, …"]
   end
 ```
 
@@ -42,7 +42,7 @@ flowchart TB
 |---|---|---|
 | Backend services | 8 | Static Go binaries (`CGO_ENABLED=0`), one per `services.yaml` entry of `type: backend` |
 | Frontend | 1 | `type: static`, npm build output served by nginx |
-| CLI tools | 4 | `duynhlab-ctl`, `duynhlab-db-setup`, `duynhlab-gen-env`, `duynhlab-gen-password` |
+| CLI tools | 4 | `duynhctl`, `duynhdb`, `duynhenv`, `duynhpass` |
 | systemd units | 8 + 2 targets | per-service `.service` + `duynhlab-platform.target` + `duynhlab-infra.target` |
 
 ### Services (from `services.yaml`)
@@ -60,7 +60,7 @@ flowchart TB
 | frontend | — | — | static, served by nginx |
 
 > `services.yaml` is the single source of truth. Adding a service there +
-> rebuilding regenerates units, the staging tree, and `duynhlab-ctl` output.
+> rebuilding regenerates units, the staging tree, and `duynhctl` output.
 
 ## 3. Filesystem layout (FHS)
 
@@ -174,7 +174,7 @@ What the scriptlets guarantee:
   `/etc/duynhlab/*.env`.
 - **No auto-start** — installing does not enable or start any unit.
 - **No auto-migrate** — the DB schema is the operator's responsibility via
-  `duynhlab-db-setup migrate`.
+  `duynhdb migrate`.
 - **No mutation of user-owned config** — nginx/valkey fragments are dropped
   under `conf.d/`, never overwriting `nginx.conf`/`valkey.conf`.
 
@@ -190,7 +190,7 @@ flowchart LR
     MIG[duynhlab_&lt;svc&gt;_migrator<br/>DDL]
   end
   RT[duynhlab-&lt;svc&gt;.service] -->|DB_PASSWORD<br/>app role| APP --> DB
-  MIGCLI[duynhlab-db-setup migrate] --> MIG --> DB
+  MIGCLI[duynhdb migrate] --> MIG --> DB
 ```
 
 - `bootstrap` (needs `SUPERUSER_DSN`) creates the database + both roles + grants.

--- a/docs/002-install.md
+++ b/docs/002-install.md
@@ -79,7 +79,7 @@ The post-install scriptlet:
 
 ## 3. Bootstrap the database (one-time)
 
-`duynhlab-db-setup` is **per-service**: each invocation takes a single service
+`duynhdb` is **per-service**: each invocation takes a single service
 name (`bootstrap <svc>` / `migrate <svc>`). It creates one database + two roles
 (`app`, `migrator`) for that service and stores the generated app-role password
 in `/etc/duynhlab/<svc>.env`.
@@ -91,11 +91,11 @@ backend services:
 export SUPERUSER_DSN="postgresql://postgres:secret@localhost:5432/postgres"
 
 for svc in auth user product cart order review notification shipping; do
-  sudo -E duynhlab-db-setup bootstrap "$svc"
+  sudo -E duynhdb bootstrap "$svc"
 done
 
 for svc in auth user product cart order review notification shipping; do
-  sudo duynhlab-db-setup migrate "$svc"
+  sudo duynhdb migrate "$svc"
 done
 ```
 
@@ -110,8 +110,8 @@ sudo systemctl enable --now duynhlab-platform.target
 Verify:
 
 ```bash
-duynhlab-ctl status            # per-service status table
-duynhlab-ctl ports             # listening port mapping
+duynhctl status            # per-service status table
+duynhctl ports             # listening port mapping
 curl -fsS http://localhost/health
 journalctl -u 'duynhlab-*' -e --no-pager
 ```
@@ -122,7 +122,7 @@ journalctl -u 'duynhlab-*' -e --no-pager
 sudo dnf upgrade -y duynhlab
 # Apply any new migrations shipped in the new RPM:
 for svc in auth user product cart order review notification shipping; do
-  sudo duynhlab-db-setup migrate "$svc"
+  sudo duynhdb migrate "$svc"
 done
 sudo systemctl restart duynhlab-platform.target
 ```
@@ -130,7 +130,7 @@ sudo systemctl restart duynhlab-platform.target
 Upgrades:
 
 - **Preserve** `/etc/duynhlab/*.env` and the database.
-- **Do not auto-migrate.** Always run `duynhlab-db-setup migrate <svc>` after an
+- **Do not auto-migrate.** Always run `duynhdb migrate <svc>` after an
   upgrade — a new binary may query tables/columns its embedded migrations have
   not created yet, failing at runtime with SQL errors. (`SCHEMA_VERSION` under
   `/opt/duynhlab/<svc>/` is audit metadata only — nothing blocks startup.)
@@ -176,16 +176,16 @@ sudo -u postgres psql -c "DROP DATABASE duynhlab_auth;" ...
 ## Troubleshooting
 
 When contacting support, attach a diagnostics bundle —
-`sudo duynhlab-ctl support-bundle` collects journals, unit status, versions and
+`sudo duynhctl support-bundle` collects journals, unit status, versions and
 non-secret configs into one tarball (**your `*.env` secrets are never
 included**).
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
 | `dnf install` fails: `Curl error (60): SSL certificate problem` | Mirror reach is restricted | `dnf install --setopt=sslverify=false` once, then fix CA |
-| Service starts but logs SQL errors (missing table/column) after an upgrade | Forgot `duynhlab-db-setup migrate auth` | Run it, then `systemctl restart duynhlab-auth` |
+| Service starts but logs SQL errors (missing table/column) after an upgrade | Forgot `duynhdb migrate auth` | Run it, then `systemctl restart duynhlab-auth` |
 | `nginx -t` fails after install | Existing `nginx.conf` already defines `server { listen 80; }` | Edit `/etc/nginx/nginx.conf` to remove the default `server` block; ours lives in `conf.d/duynhlab.conf` |
-| `duynhlab-ctl status` shows `inactive (dead)` | DB unreachable or password wrong | `grep DB_PASSWORD /etc/duynhlab/<svc>.env`, verify via `psql` |
+| `duynhctl status` shows `inactive (dead)` | DB unreachable or password wrong | `grep DB_PASSWORD /etc/duynhlab/<svc>.env`, verify via `psql` |
 
 ## Local-mirror testing
 

--- a/docs/003-operations.md
+++ b/docs/003-operations.md
@@ -5,41 +5,41 @@ databases, and troubleshooting. All commands assume `root` (or `sudo`).
 
 ---
 
-## 1. `duynhlab-ctl` — service control
+## 1. `duynhctl` — service control
 
 A thin, safe wrapper around `systemctl`/`journalctl` that knows the service
 list from `/etc/duynhlab/services.yaml` (parsed with mikefarah `yq`, which the
 RPM pulls automatically via `Requires: yq` — no manual install needed).
 
 ```
-duynhlab-ctl <command> [svc|all] [args]
+duynhctl <command> [svc|all] [args]
 ```
 
 | Command | Example | Description |
 |---|---|---|
-| `list` | `duynhlab-ctl list` | List all services from `services.yaml` |
-| `status` | `duynhlab-ctl status all` | systemd status table |
-| `start` | `duynhlab-ctl start auth` | Start service(s) |
-| `stop` | `duynhlab-ctl stop all` | Stop service(s) |
-| `restart` | `duynhlab-ctl restart order` | Restart service(s) |
-| `enable` | `duynhlab-ctl enable all` | Enable on boot |
-| `disable` | `duynhlab-ctl disable user` | Disable on boot |
-| `logs` | `duynhlab-ctl logs auth -f` | Tail journal (extra args → `journalctl`) |
-| `health` | `duynhlab-ctl health all` | `curl /health` on each configured port |
-| `version` | `duynhlab-ctl version all` | Print binary + schema versions |
-| `config` | `duynhlab-ctl config auth` | Show env file (password masked) |
-| `ports` | `duynhlab-ctl ports` | Port assignment table |
-| `support-bundle` | `duynhlab-ctl support-bundle [dir]` | Diagnostics tarball for support: 7 days of journals, unit status, manifest, versions, install history, non-secret configs. **`*.env` / `*.override` are never included** |
+| `list` | `duynhctl list` | List all services from `services.yaml` |
+| `status` | `duynhctl status all` | systemd status table |
+| `start` | `duynhctl start auth` | Start service(s) |
+| `stop` | `duynhctl stop all` | Stop service(s) |
+| `restart` | `duynhctl restart order` | Restart service(s) |
+| `enable` | `duynhctl enable all` | Enable on boot |
+| `disable` | `duynhctl disable user` | Disable on boot |
+| `logs` | `duynhctl logs auth -f` | Tail journal (extra args → `journalctl`) |
+| `health` | `duynhctl health all` | `curl /health` on each configured port |
+| `version` | `duynhctl version all` | Print binary + schema versions |
+| `config` | `duynhctl config auth` | Show env file (password masked) |
+| `ports` | `duynhctl ports` | Port assignment table |
+| `support-bundle` | `duynhctl support-bundle [dir]` | Diagnostics tarball for support: 7 days of journals, unit status, manifest, versions, install history, non-secret configs. **`*.env` / `*.override` are never included** |
 
 `svc` accepts a single name or `all`. Health/version iterate every service.
 
-## 2. `duynhlab-db-setup` — database management
+## 2. `duynhdb` — database management
 
 Operates **per service**. Reads connection settings from
 `/etc/duynhlab/<svc>.env`.
 
 ```
-duynhlab-db-setup <bootstrap|migrate|status> <svc>
+duynhdb <bootstrap|migrate|status> <svc>
 ```
 
 | Subcommand | Needs | Description |
@@ -59,8 +59,8 @@ duynhlab-db-setup <bootstrap|migrate|status> <svc>
 ```bash
 export SUPERUSER_DSN="postgresql://postgres:secret@localhost:5432/postgres"
 for svc in auth user product cart order review notification shipping; do
-  duynhlab-db-setup bootstrap "$svc"
-  duynhlab-db-setup migrate   "$svc"
+  duynhdb bootstrap "$svc"
+  duynhdb migrate   "$svc"
 done
 ```
 
@@ -74,14 +74,14 @@ flowchart LR
   I[dnf install duynhlab] --> B["db-setup bootstrap &lt;svc&gt;<br/>(per backend)"]
   B --> M["db-setup migrate &lt;svc&gt;"]
   M --> E[systemctl enable --now<br/>duynhlab-platform.target]
-  E --> V[duynhlab-ctl status / health]
+  E --> V[duynhctl status / health]
 ```
 
 ```bash
 # after bootstrap + migrate:
 systemctl enable --now duynhlab-platform.target
-duynhlab-ctl status all
-duynhlab-ctl health all
+duynhctl status all
+duynhctl health all
 curl -fsS http://localhost/health
 ```
 
@@ -135,7 +135,7 @@ reason about). Put changes in `<svc>.override`, then
 dnf upgrade -y duynhlab
 # apply any migrations shipped in the new payload, per backend:
 for svc in auth user product cart order review notification shipping; do
-  duynhlab-db-setup migrate "$svc"
+  duynhdb migrate "$svc"
 done
 systemctl restart duynhlab-platform.target
 ```
@@ -165,12 +165,12 @@ sudo -u postgres psql -c "DROP DATABASE duynhlab_auth;"   # … per service
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
-| `duynhlab-ctl status` shows `inactive (dead)` | DB unreachable / wrong password | `duynhlab-ctl config <svc>`, verify with `psql` |
-| Service logs SQL errors (missing table/column) after upgrade | Forgot `migrate` | `duynhlab-db-setup migrate <svc>`, restart |
+| `duynhctl status` shows `inactive (dead)` | DB unreachable / wrong password | `duynhctl config <svc>`, verify with `psql` |
+| Service logs SQL errors (missing table/column) after upgrade | Forgot `migrate` | `duynhdb migrate <svc>`, restart |
 | `nginx -t` fails after install | Existing `server { listen 80; }` in `nginx.conf` | Remove the default server block; ours is in `conf.d/duynhlab.conf` |
-| `health` reports connection refused | Service not started or wrong port | `duynhlab-ctl start <svc>`; check `duynhlab-ctl ports` |
+| `health` reports connection refused | Service not started or wrong port | `duynhctl start <svc>`; check `duynhctl ports` |
 | `db-setup bootstrap` errors `SUPERUSER_DSN` | Env var not exported | `export SUPERUSER_DSN=postgresql://postgres:…` |
-| `db-setup` errors `DB_PASSWORD empty` | Env file not generated | Reinstall, or run `duynhlab-gen-password` |
+| `db-setup` errors `DB_PASSWORD empty` | Env file not generated | Reinstall, or run `duynhpass` |
 
 See [install.md](002-install.md) for first-time setup and [architecture.md](001-architecture.md)
 for the systemd/DB model.

--- a/docs/004-build.md
+++ b/docs/004-build.md
@@ -204,7 +204,7 @@ from `python3 -m http.server`.
 1. Add an entry to [`services.yaml`](../services.yaml) (name, repo, port, type,
    and `database` if it needs one).
 2. `make fetch-sources build-local-all build` — units, staging tree, and
-   `duynhlab-ctl` pick it up automatically.
+   `duynhctl` pick it up automatically.
 3. Update the hard-coded service loop in
    [`packages/rpm/duynhlab.spec`](../packages/rpm/duynhlab.spec) `%check`/`%post` if the new
    service is a backend (the spec lists the eight backends explicitly).

--- a/docs/006-add-service.md
+++ b/docs/006-add-service.md
@@ -15,12 +15,12 @@ conventions or the pipeline can't build/run it:
 - **Migrations embedded in the binary**: `db/migrations/sql/000NNN_*.up.sql`
   (forward-only, no `.down.sql`), embedded via `//go:embed` and applied by the
   binary's own `migrate` subcommand through `github.com/duynhlab/pkg/migratex`.
-  `duynhlab-db-setup migrate payments` execs exactly that.
+  `duynhdb migrate payments` execs exactly that.
 - **Config via discrete env vars** (no `DATABASE_URL`): `DB_HOST DB_PORT
   DB_NAME DB_USER DB_PASSWORD DB_SSLMODE`, plus `PORT` (and `GRPC_PORT` if it
   serves gRPC). Defaults of 8080/9090 in code are fine — the RPM overrides
   them per service.
-- **`GET /health`** returning 200 on the HTTP port — `duynhlab-ctl health` and
+- **`GET /health`** returning 200 on the HTTP port — `duynhctl health` and
   the integration test poll it.
 - Logs to stdout/stderr (journald captures them).
 
@@ -80,8 +80,8 @@ grep -rn "notification shipping" scripts/ packages/ | grep -v payments && echo "
 
 `fetch-sources.sh`, `build-local.sh`, `render-systemd.sh` (unit + platform
 target), `stage-all.sh` (staging + composition manifest), `Makefile
-build-local-all`, `duynhlab-ctl` (list/health/ports), `password-generator.sh`
-(scans `secret-tpl/*.env.tpl`), `duynhlab-db-setup` (per-service args),
+build-local-all`, `duynhctl` (list/health/ports), `password-generator.sh`
+(scans `secret-tpl/*.env.tpl`), `duynhdb` (per-service args),
 `bootstrap.sql`. They all iterate the registry — no edits needed.
 
 ## 5. Build & verify locally
@@ -104,8 +104,8 @@ On a test host (or in the integration container):
 
 ```bash
 SUPERUSER_DSN="postgresql://postgres:…@localhost:5432/postgres" \
-  sudo -E duynhlab-db-setup bootstrap payments
-sudo duynhlab-db-setup migrate payments
+  sudo -E duynhdb bootstrap payments
+sudo duynhdb migrate payments
 sudo systemctl start duynhlab-payments && curl -fsS localhost:8009/health
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ the one that matches your task.
 |---|---|---|---|
 | 001 | [`001-architecture.md`](001-architecture.md) | Anyone | Why a mega-RPM, component map, services table, FHS layout, systemd model, install/upgrade/remove lifecycle diagrams, database model |
 | 002 | [`002-install.md`](002-install.md) | Operators installing the RPM | Add the repo, install, bootstrap the database, start, upgrade, downgrade, remove, troubleshooting |
-| 003 | [`003-operations.md`](003-operations.md) | Operators (day-2) | `duynhlab-ctl` and `duynhlab-db-setup` reference, bring-up flow, systemd targets, configuration files, upgrade, remove, troubleshooting |
+| 003 | [`003-operations.md`](003-operations.md) | Operators (day-2) | `duynhctl` and `duynhdb` reference, bring-up flow, systemd targets, configuration files, upgrade, remove, troubleshooting |
 | 004 | [`004-build.md`](004-build.md) | Contributors / release engineers | Build pipeline, scripts, runner auto-detection, Makefile targets, CI workflows, gh-pages publishing, versioning |
 | 005 | [`005-release.md`](005-release.md) | Release engineers | Runbook: cut a release, same-day hotfix, re-publish a tag, rollback/downgrade, audit composition, troubleshooting per job |
 | 006 | [`006-add-service.md`](006-add-service.md) | Contributors | Onboard a new service: repo prerequisites, `services.yaml` entry, the full hardcoded touch-point checklist, verify, ship |
@@ -24,7 +24,7 @@ the one that matches your task.
 - Diagrams are [Mermaid](https://mermaid.js.org/) and render natively on GitHub.
 - Service set: `auth user product cart order review notification shipping` (8
   backends) plus the static `frontend`.
-- `duynhlab-db-setup` is **per-service** — every invocation takes one service
-  name (e.g. `duynhlab-db-setup migrate auth`).
+- `duynhdb` is **per-service** — every invocation takes one service
+  name (e.g. `duynhdb migrate auth`).
 - Paths follow the FHS split: `/opt/duynhlab` (immutable payload) vs
   `/etc/duynhlab` (mutable env/state, preserved across upgrades).

--- a/packages/common/scripts/duynhctl
+++ b/packages/common/scripts/duynhctl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# duynhlab-ctl — operational wrapper around systemctl/journalctl for duynhlab services.
+# duynhctl — operational wrapper around systemctl/journalctl for duynhlab services.
 #
 # Commands:
 #   list                        List all services declared in services.yaml

--- a/packages/common/scripts/duynhctl.bash-completion
+++ b/packages/common/scripts/duynhctl.bash-completion
@@ -1,5 +1,5 @@
-# bash completion for duynhlab-ctl
-_duynhlab_ctl() {
+# bash completion for duynhctl
+_duynhctl() {
   local cur prev words cword
   _init_completion || return
 
@@ -22,4 +22,4 @@ _duynhlab_ctl() {
       COMPREPLY=( $(compgen -W "$svcs" -- "$cur") ) ;;
   esac
 }
-complete -F _duynhlab_ctl duynhlab-ctl
+complete -F _duynhctl duynhctl

--- a/packages/common/scripts/duynhdb
+++ b/packages/common/scripts/duynhdb
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# duynhlab-db-setup — manage per-service PostgreSQL databases on duynhlab hosts.
+# duynhdb — manage per-service PostgreSQL databases on duynhlab hosts.
 #
 # Subcommands:
 #   bootstrap <svc>   CREATE DATABASE + CREATE USER + GRANT (needs SUPERUSER_DSN)

--- a/packages/common/scripts/duynhenv
+++ b/packages/common/scripts/duynhenv
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# duynhlab-gen-env <service>
+# duynhenv <service>
 #
 # Render /etc/duynhlab/<svc>.env from /opt/duynhlab/secret-tpl/<svc>.env.tpl
 # substituting __DB_PASSWORD__ with a fresh random 32-char string.
@@ -9,7 +9,7 @@ set -eu
 PROG=${0##*/}
 TPL_DIR=${TPL_DIR:-/opt/duynhlab/secret-tpl}
 ETC=${ETC:-/etc/duynhlab}
-GEN_PASS=${GEN_PASS:-/opt/duynhlab/lib/duynhlab-gen-password}
+GEN_PASS=${GEN_PASS:-/opt/duynhlab/lib/duynhpass}
 
 force=0
 svc=""

--- a/packages/common/scripts/duynhpass
+++ b/packages/common/scripts/duynhpass
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# duynhlab-gen-password — generate a cryptographically random password.
-# Usage: duynhlab-gen-password [length]   (default 32)
+# duynhpass — generate a cryptographically random password.
+# Usage: duynhpass [length]   (default 32)
 set -eu
 LEN=${1:-32}
 [[ "$LEN" =~ ^[0-9]+$ ]] && [[ "$LEN" -ge 8 ]] || {

--- a/packages/rpm/duynhlab.spec
+++ b/packages/rpm/duynhlab.spec
@@ -39,7 +39,7 @@ Requires:       coreutils
 Requires:       nginx >= 1.20
 Requires:       postgresql >= 14
 Requires:       valkey >= 7.2
-# mikefarah yq (EPEL ≥4.47 on EL9) — duynhlab-ctl parses services.yaml with it.
+# mikefarah yq (EPEL ≥4.47 on EL9) — duynhctl parses services.yaml with it.
 # EPEL is already a documented prerequisite (valkey lives there too).
 Requires:       yq >= 4
 Requires(pre):  shadow-utils
@@ -57,15 +57,15 @@ duynhlab e-commerce platform — single mega-RPM containing:
   * 8 Go backend services (auth, user, product, cart, order, review,
     notification, shipping) under /opt/duynhlab/<svc>/bin/
   * Frontend SPA (static dist) under /opt/duynhlab/frontend/dist/
-  * CLI tools: duynhlab-ctl, duynhlab-db-setup, duynhlab-gen-env,
-    duynhlab-gen-password
+  * CLI tools: duynhctl, duynhdb, duynhenv,
+    duynhpass
   * Per-service systemd units + duynhlab-platform.target + duynhlab-infra.target
   * Template configs for nginx, valkey, postgresql, logrotate
   * Idempotent init-service.sh that drops configs into /etc/ on first install
   * Random password generation on first install (preserved on upgrade)
 
 Install:  dnf install duynhlab
-Bootstrap: duynhlab-db-setup bootstrap <svc> && duynhlab-db-setup migrate <svc>
+Bootstrap: duynhdb bootstrap <svc> && duynhdb migrate <svc>
            (migrate runs the service binary's own embedded migrations)
 Start:    systemctl enable --now duynhlab-platform.target
 
@@ -90,15 +90,15 @@ cp -a opt/duynhlab/. %{buildroot}%{duynhlab_prefix}/
 cp -a systemd/. %{buildroot}%{_unitdir}/
 
 # 3. /usr/bin symlinks to /opt/duynhlab/lib/* CLI tools
-for tool in duynhlab-ctl duynhlab-db-setup \
-            duynhlab-gen-env duynhlab-gen-password; do
+for tool in duynhctl duynhdb \
+            duynhenv duynhpass; do
   ln -sf %{duynhlab_prefix}/lib/$tool %{buildroot}%{_bindir}/$tool
 done
 
 # 4. Bash completion (optional, ship if exists)
-if [ -f opt/duynhlab/lib/duynhlab-ctl.bash-completion ]; then
-  install -Dm 0644 opt/duynhlab/lib/duynhlab-ctl.bash-completion \
-    %{buildroot}%{_datadir}/bash-completion/completions/duynhlab-ctl
+if [ -f opt/duynhlab/lib/duynhctl.bash-completion ]; then
+  install -Dm 0644 opt/duynhlab/lib/duynhctl.bash-completion \
+    %{buildroot}%{_datadir}/bash-completion/completions/duynhctl
 fi
 
 %check
@@ -177,16 +177,16 @@ cat <<'EOF'
 
     # 1. Bootstrap PostgreSQL (one-time, per service):
     SUPERUSER_DSN="postgresql://postgres:secret@localhost:5432/postgres" \
-      duynhlab-db-setup bootstrap auth
+      duynhdb bootstrap auth
 
     # 2. Run migrations (runs the service binary's embedded migrations):
-    duynhlab-db-setup migrate auth
+    duynhdb migrate auth
 
     # 3. Start platform:
     systemctl enable --now duynhlab-platform.target
 
     # 4. Verify:
-    duynhlab-ctl status
+    duynhctl status
     curl http://localhost/health
 ================================================================
 EOF
@@ -240,13 +240,13 @@ exit 0
 %{duynhlab_prefix}/lib
 
 # /usr/bin symlinks
-%{_bindir}/duynhlab-ctl
-%{_bindir}/duynhlab-db-setup
-%{_bindir}/duynhlab-gen-env
-%{_bindir}/duynhlab-gen-password
+%{_bindir}/duynhctl
+%{_bindir}/duynhdb
+%{_bindir}/duynhenv
+%{_bindir}/duynhpass
 
 # Optional bash completion
-%{_datadir}/bash-completion/completions/duynhlab-ctl
+%{_datadir}/bash-completion/completions/duynhctl
 
 # Systemd units
 %{_unitdir}/duynhlab-infra.target

--- a/packages/rpm/lib/password-generator.sh
+++ b/packages/rpm/lib/password-generator.sh
@@ -23,8 +23,8 @@ TPL=/opt/duynhlab/secret-tpl
 STATE_FILE="$ETC/secret_version.properties"
 CURRENT_SECRET_VERSION=1
 
-GEN_PASS=/opt/duynhlab/lib/duynhlab-gen-password
-GEN_ENV=/opt/duynhlab/lib/duynhlab-gen-env
+GEN_PASS=/opt/duynhlab/lib/duynhpass
+GEN_ENV=/opt/duynhlab/lib/duynhenv
 
 log() { printf '[password-generator] %s\n' "$*"; }
 
@@ -59,7 +59,7 @@ if [ "$have" -lt 1 ]; then
     if [ -x "$GEN_ENV" ]; then
       "$GEN_ENV" "$svc"
     else
-      # Inline fallback if duynhlab-gen-env is missing.
+      # Inline fallback if duynhenv is missing.
       pass=$("$GEN_PASS" 32 2>/dev/null || \
              tr -dc 'A-Za-z0-9' </dev/urandom 2>/dev/null | head -c 32)
       sed "s/__DB_PASSWORD__/${pass}/g" "$tpl" > "$env_file"

--- a/packages/rpm/postgresql/bootstrap.sql
+++ b/packages/rpm/postgresql/bootstrap.sql
@@ -1,9 +1,9 @@
 -- bootstrap.sql — duynhlab per-service databases + roles.
 --
--- Rendered/applied by /usr/bin/duynhlab-db-setup as the postgres superuser.
+-- Rendered/applied by /usr/bin/duynhdb as the postgres superuser.
 -- Idempotent: uses DO blocks + IF NOT EXISTS guards.
 --
--- This file is a TEMPLATE — duynhlab-db-setup substitutes:
+-- This file is a TEMPLATE — duynhdb substitutes:
 --   :svc        short name (e.g. auth)
 --   :db         duynhlab_<svc>
 --   :app_user   duynhlab_<svc>_app

--- a/packages/rpm/scriptlets/common-postinstall.sh
+++ b/packages/rpm/scriptlets/common-postinstall.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 set -e
 systemctl daemon-reload >/dev/null 2>&1 || :
-echo "duynhlab-common installed. Run 'duynhlab-ctl list' to see services."
+echo "duynhlab-common installed. Run 'duynhctl list' to see services."
 exit 0

--- a/packages/rpm/scriptlets/postinstall.sh.tmpl
+++ b/packages/rpm/scriptlets/postinstall.sh.tmpl
@@ -11,7 +11,7 @@ TEMPLATE="${ETC_DIR}/${SVC}.env.template"
 mkdir -p "${ETC_DIR}"
 
 if [ ! -f "${ENV_FILE}" ]; then
-  PASS="$(/usr/bin/duynhlab-gen-password 32 2>/dev/null || \
+  PASS="$(/usr/bin/duynhpass 32 2>/dev/null || \
           tr -dc 'A-Za-z0-9' </dev/urandom | head -c 32)"
 
   cat > "${ENV_FILE}" <<EOF
@@ -42,8 +42,8 @@ EOF
   echo ""
   echo "  Next steps (as root):"
   echo "    SUPERUSER_DSN=postgresql://postgres:secret@localhost:5432/postgres \\"
-  echo "      duynhlab-db-setup bootstrap ${SVC}"
-  echo "    duynhlab-db-setup migrate ${SVC}"
+  echo "      duynhdb bootstrap ${SVC}"
+  echo "    duynhdb migrate ${SVC}"
   echo "    systemctl enable --now duynhlab-${SVC}"
   echo "================================================================"
 else

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -37,7 +37,7 @@ require_cmd() {
 # ── services.yaml parser (mikefarah yq v4) ────────────────────────────────────
 # BUILD-TIME dependency — runs on the developer machine / CI runner that BUILDS
 # the RPM. Do not confuse it with the spec's `Requires: yq`, which only applies
-# to CUSTOMER hosts that INSTALL the RPM (it covers duynhlab-ctl at runtime and
+# to CUSTOMER hosts that INSTALL the RPM (it covers duynhctl at runtime and
 # does nothing for build machines).
 #   CI:  installed by .github/workflows/_build-test.yml (curl from GitHub —
 #        Ubuntu's `apt install yq` is the unrelated python-yq, wrong tool).

--- a/scripts/publish-yum-repo.sh
+++ b/scripts/publish-yum-repo.sh
@@ -189,8 +189,8 @@ sudo dnf install -y duynhlab</pre>
 <h2>Bootstrap</h2>
 <pre>for svc in auth user product cart order review notification shipping; do
   SUPERUSER_DSN="postgresql://postgres:secret@localhost:5432/postgres" \\
-    sudo -E duynhlab-db-setup bootstrap "\$svc"
-  sudo duynhlab-db-setup migrate "\$svc"
+    sudo -E duynhdb bootstrap "\$svc"
+  sudo duynhdb migrate "\$svc"
 done
 sudo systemctl enable --now duynhlab-platform.target</pre>
 

--- a/scripts/stage-all.sh
+++ b/scripts/stage-all.sh
@@ -8,8 +8,8 @@
 #   opt/duynhlab/etc/{services.yaml, env-global.properties}
 #   opt/duynhlab/{nginx,valkey,postgresql,secret-tpl,logrotate}/...
 #   opt/duynhlab/lib/{init-service.sh, password-generator.sh,
-#                     duynhlab-ctl, duynhlab-db-setup, duynhlab-gen-env,
-#                     duynhlab-gen-password, duynhlab-ctl.bash-completion}
+#                     duynhctl, duynhdb, duynhenv,
+#                     duynhpass, duynhctl.bash-completion}
 #   systemd/duynhlab-*.{service,target}
 #
 # Final tarball:
@@ -84,15 +84,15 @@ tar -xzf "$frontend_tgz" -C "$OPT/frontend"
 log_ok "staged frontend"
 
 # ── 3. CLI tools + library scripts ────────────────────────────────────────────
-install -m 0755 "$REPO_ROOT/packages/common/scripts/duynhlab-ctl"           "$OPT/lib/"
-install -m 0755 "$REPO_ROOT/packages/common/scripts/duynhlab-db-setup"      "$OPT/lib/"
-install -m 0755 "$REPO_ROOT/packages/common/scripts/duynhlab-gen-env"       "$OPT/lib/"
-install -m 0755 "$REPO_ROOT/packages/common/scripts/duynhlab-gen-password"  "$OPT/lib/"
-install -m 0644 "$REPO_ROOT/packages/common/scripts/duynhlab-ctl.bash-completion" "$OPT/lib/"
+install -m 0755 "$REPO_ROOT/packages/common/scripts/duynhctl"           "$OPT/lib/"
+install -m 0755 "$REPO_ROOT/packages/common/scripts/duynhdb"      "$OPT/lib/"
+install -m 0755 "$REPO_ROOT/packages/common/scripts/duynhenv"       "$OPT/lib/"
+install -m 0755 "$REPO_ROOT/packages/common/scripts/duynhpass"  "$OPT/lib/"
+install -m 0644 "$REPO_ROOT/packages/common/scripts/duynhctl.bash-completion" "$OPT/lib/"
 install -m 0755 "$REPO_ROOT/packages/rpm/lib/init-service.sh"               "$OPT/lib/"
 install -m 0755 "$REPO_ROOT/packages/rpm/lib/password-generator.sh"         "$OPT/lib/"
 log_ok "staged CLI + lib"
-# NOTE: duynhlab-ctl's yq comes via `Requires: yq` in the spec (EPEL ships
+# NOTE: duynhctl's yq comes via `Requires: yq` in the spec (EPEL ships
 # mikefarah yq ≥4.47 on EL9) — nothing to bundle here.
 
 # ── 4. Config templates ───────────────────────────────────────────────────────

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -39,7 +39,7 @@ echo "::group::Repo + dependency setup"
 dnf -y install epel-release >/dev/null
 dnf -y module enable postgresql:16 >/dev/null
 # Valkey lives in EPEL on EL9; nginx in AppStream.
-# Deliberately NO yq here: customer hosts won't have it — duynhlab-ctl must
+# Deliberately NO yq here: customer hosts won't have it — duynhctl must
 # work with the copy bundled in the RPM (/opt/duynhlab/lib/yq).
 dnf -y install postgresql nginx valkey shadow-utils which file >/dev/null
 echo "::endgroup::"
@@ -83,23 +83,23 @@ echo "Layout OK"
 echo "::endgroup::"
 
 echo "::group::CLI symlinks"
-for c in duynhlab-ctl duynhlab-db-setup \
-         duynhlab-gen-env duynhlab-gen-password; do
+for c in duynhctl duynhdb \
+         duynhenv duynhpass; do
   which "$c"
 done
 # duynhlab-db-migrate must NOT exist anymore (D23).
 ! which duynhlab-db-migrate 2>/dev/null || { echo "UNEXPECTED duynhlab-db-migrate present"; exit 1; }
-duynhlab-gen-password 16 || true
+duynhpass 16 || true
 test -f /etc/duynhlab/services.yaml || { echo "services.yaml not dropped"; exit 1; }
 echo "::endgroup::"
 
-echo "::group::duynhlab-ctl works out-of-box (yq pulled as RPM dependency)"
+echo "::group::duynhctl works out-of-box (yq pulled as RPM dependency)"
 # We never install yq by hand in this test — `Requires: yq` must have made dnf
 # pull it (mikefarah yq from EPEL). This reproduces a clean customer host.
 command -v yq >/dev/null 2>&1 || { echo "MISSING yq — Requires: yq not resolved"; exit 1; }
 yq --version | grep -q mikefarah || { echo "WRONG yq (expected mikefarah): $(yq --version)"; exit 1; }
-duynhlab-ctl list
-duynhlab-ctl ports
+duynhctl list
+duynhctl ports
 echo "::endgroup::"
 
 echo "::group::secret versioning — re-running the generator must change nothing"
@@ -121,7 +121,7 @@ cat /var/log/duynhlab/version.log
 echo "::endgroup::"
 
 echo "::group::support-bundle contains NO secrets"
-duynhlab-ctl support-bundle /tmp
+duynhctl support-bundle /tmp
 bundle=$(ls /tmp/duynhlab-support-*.tar.gz | head -1)
 [ -f "$bundle" ] || { echo "NO bundle produced"; exit 1; }
 # Take a real password value and prove it is absent from the bundle.
@@ -184,10 +184,10 @@ test -d /var/log/duynhlab/nginx
 ls -ld /var/log/duynhlab /var/log/duynhlab/auth /var/log/duynhlab/nginx
 echo "::endgroup::"
 
-echo "::group::duynhlab-ctl basic commands"
-duynhlab-ctl list || true
-duynhlab-ctl ports || true
-duynhlab-ctl version || true
+echo "::group::duynhctl basic commands"
+duynhctl list || true
+duynhctl ports || true
+duynhctl version || true
 echo "::endgroup::"
 
 echo "::group::Reinstall preserves env"

--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -8,11 +8,11 @@
 # In the app container we:
 #   1. install epel + nginx + valkey + postgresql client
 #   2. dnf localinstall the mega-RPM
-#   3. duynhlab-db-setup <svc> bootstrap   (loop services with DB)
-#   4. duynhlab-db-setup <svc> migrate
+#   3. duynhdb <svc> bootstrap   (loop services with DB)
+#   4. duynhdb <svc> migrate
 #   5. systemctl start duynhlab-platform.target
 #   6. curl localhost:<port>/health for every backend
-#   7. duynhlab-ctl status / logs sanity
+#   7. duynhctl status / logs sanity
 #   8. shutdown
 #
 # Requires: podman with cgroup v2 + `--systemd=true` support (default on
@@ -161,9 +161,9 @@ for svc in "${BACKENDS[@]}"; do
   exec_app "
     set -e
     SUPERUSER_DSN='postgresql://postgres:${POSTGRES_PASSWORD}@127.0.0.1:5432/postgres?sslmode=disable' \
-      duynhlab-db-setup bootstrap $svc
-    duynhlab-db-setup migrate $svc
-    duynhlab-db-setup status   $svc
+      duynhdb bootstrap $svc
+    duynhdb migrate $svc
+    duynhdb status   $svc
   "
 done
 log_ok "DB bootstrap + migrate OK"
@@ -194,9 +194,9 @@ for svc in "${BACKENDS[@]}"; do
   fi
 done
 
-# ── 7. duynhlab-ctl sanity ────────────────────────────────────────────────────
-log_step "duynhlab-ctl status / ports"
-exec_app 'duynhlab-ctl status || true; echo ; duynhlab-ctl ports || true'
+# ── 7. duynhctl sanity ────────────────────────────────────────────────────
+log_step "duynhctl status / ports"
+exec_app 'duynhctl status || true; echo ; duynhctl ports || true'
 
 # ── 8. Clean shutdown ─────────────────────────────────────────────────────────
 log_step "systemctl stop duynhlab-platform.target"

--- a/services.yaml
+++ b/services.yaml
@@ -10,7 +10,7 @@
 #   build_path    Go package main path (default ./cmd)
 #   port          HTTP listen port. INJECTED as PORT= into <svc>.env. Every service
 #                 defaults to 8080 in code, so on a shared host this override is
-#                 MANDATORY to avoid collision (also used by duynhlab-ctl health).
+#                 MANDATORY to avoid collision (also used by duynhctl health).
 #   grpc_port     gRPC listen port. INJECTED as GRPC_PORT= into <svc>.env. Only set
 #                 for services that run a gRPC server (default 9090 in code →
 #                 collides on a shared host). Omit for HTTP-only services.
@@ -21,7 +21,7 @@
 # Migrations: each backend EMBEDS its own SQL (go:embed) and runs them via its own
 # `<binary> migrate` subcommand (golang-migrate v4 through duynhlab/pkg/migratex,
 # forward-only *.up.sql). The packages repo does NOT ship loose SQL or a separate
-# migrate binary — see plan.md D23/D24. `duynhlab-db-setup <svc> migrate` just execs
+# migrate binary — see plan.md D23/D24. `duynhdb <svc> migrate` just execs
 # `<binary> migrate` with the migrator DB_USER/DB_PASSWORD in the environment.
 #
 # DB env vars read by every backend (no DATABASE_URL): DB_HOST, DB_PORT (5432),


### PR DESCRIPTION
## What

Mechanical rename of the four CLI entry points to shorter names:

| Old | New |
|---|---|
| `duynhlab-ctl` | `duynhctl` |
| `duynhlab-db-setup` | `duynhdb` |
| `duynhlab-gen-env` | `duynhenv` |
| `duynhlab-gen-password` | `duynhpass` |

> ⚠️ **BREAKING — no compat symlinks.** After upgrading, the old command names are gone; any operator script calling them must switch. Decided to cut clean since the first release shipped only days ago.

**Unchanged**: package name `duynhlab`, `/opt/duynhlab`, `/etc/duynhlab`, systemd units/targets (`duynhlab-*`), user/group, support-bundle prefix (`duynhlab-support-*`), env vars.

## Scope

- `git mv` of the 5 files under `packages/common/scripts/` (history preserved; bash-completion file + `_duynhctl` function renamed too)
- spec: `%install` `/usr/bin` symlink loop, completion install path, `%files`, `%description`, post-install hints
- scripts/tests: `stage-all.sh`, `publish-yum-repo.sh`, `test-install.sh`, `test-integration.sh`, scriptlets, `password-generator.sh` internals (`GEN_PASS`/`GEN_ENV` paths)
- docs: README, AGENTS.md, `docs/001–006`

## Verification

- `git grep` for any old name → zero hits
- `bash -n` all scripts; completion sources and defines `_duynhctl`
- `make build` + `make test-install` **PASSED** end-to-end: new `/usr/bin` symlinks resolved, `duynhctl list/ports/support-bundle` work out-of-box, secret-versioning idempotency + version.log + no-secret-leak assertions all green
- test-integration runs in this PR's CI